### PR TITLE
Refresh Topology before Subsequent Operations

### DIFF
--- a/src/fuzzer_engine/cluster_coordinator.py
+++ b/src/fuzzer_engine/cluster_coordinator.py
@@ -113,10 +113,10 @@ class ClusterCoordinator:
             # Validate cluster health with live nodes only
             is_healthy = self.cluster_manager.validate_cluster(nodes_to_validate)
             
-            # Count assigned slots
+            # Count assigned slots from live primary nodes only
             total_slots = sum(
                 (node.slot_end - node.slot_start + 1) 
-                for node in cluster_instance.nodes 
+                for node in nodes_to_validate 
                 if node.role == 'primary' and node.slot_start is not None
             )
             

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -77,8 +77,8 @@ class OperationOrchestrator(IOperationOrchestrator):
         """
         logging.info(f"Executing failover on {operation.target_node}")
         
-        # Get current cluster nodes
-        current_nodes = self.cluster_connection.get_current_nodes()
+        # Get only live cluster nodes for operation execution
+        current_nodes = self.cluster_connection.get_live_nodes()
         
         # Find target node using exact matching
         target_node = None

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -258,8 +258,8 @@ class OperationOrchestrator(IOperationOrchestrator):
         # For failover, we wait for cluster to stabilize
         while time.time() < deadline:
             try:
-                # Get current cluster state
-                current_nodes = self.cluster_connection.get_current_nodes()
+                # Get current cluster state - use live nodes only
+                current_nodes = self.cluster_connection.get_live_nodes()
                 
                 if not current_nodes:
                     time.sleep(1)
@@ -269,7 +269,7 @@ class OperationOrchestrator(IOperationOrchestrator):
                 # For failover, we expect the cluster to have all nodes connected
                 # and slots properly assigned
                 
-                # Simple check: verify we can connect to nodes
+                # Connect to a live node to check cluster state
                 any_node = current_nodes[0]
                 client = valkey.Valkey(
                     host=any_node['host'],

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -198,9 +198,12 @@ class StateValidator(IStateValidator):
                 
                 node_id = parts[0]
                 flags = parts[2]
+                link_state = parts[7] if len(parts) > 7 else 'connected'
                 
-                # Track live nodes
-                is_live = 'fail' not in flags and 'disconnected' not in flags
+                # Track live nodes - check for explicit fail/fail? tokens and disconnected link state
+                flag_list = flags.split(',')
+                has_fail_flag = 'fail' in flag_list or 'fail?' in flag_list
+                is_live = not has_fail_flag and link_state != 'disconnected'
                 if is_live:
                     live_node_ids.add(node_id)
                 

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -152,7 +152,7 @@ class StateValidator(IStateValidator):
             return False, []
         
         try:
-            # Connect to first node to get cluster info
+            # Connect to first live node to get cluster info
             node = current_nodes[0]
             client = valkey.Valkey(
                 host=node['host'],
@@ -175,7 +175,7 @@ class StateValidator(IStateValidator):
             # Get cluster nodes to check for conflicts
             cluster_nodes = client.execute_command('CLUSTER', 'NODES')
             
-            # Parse slot assignments
+            # Parse slot assignments, but only from live nodes (not failed/disconnected)
             slot_assignments: Dict[int, List[str]] = {}
             for line in cluster_nodes.split('\n'):
                 if not line.strip():
@@ -185,6 +185,12 @@ class StateValidator(IStateValidator):
                     continue
                 
                 node_id = parts[0]
+                flags = parts[2]
+                
+                # Skip failed or disconnected nodes - they shouldn't count for slot coverage
+                if 'fail' in flags or 'disconnected' in flags:
+                    continue
+                
                 # Slots are in parts[8:]
                 for slot_range in parts[8:]:
                     if '-' in slot_range:
@@ -206,14 +212,19 @@ class StateValidator(IStateValidator):
             
             client.close()
             
-            # Check for conflicts
+            # Check for conflicts (multiple live nodes claiming same slot)
             conflicts = []
             for slot, nodes in slot_assignments.items():
                 if len(nodes) > 1:
                     conflicts.append(SlotConflict(slot=slot, conflicting_nodes=nodes))
             
-            # Slot coverage is good if all slots assigned and no failures
-            slot_coverage = (slots_assigned == 16384 and slots_fail == 0)
+            # Slot coverage is good if all slots are assigned to live nodes
+            # Check that we have all 16384 slots covered by live nodes
+            slots_covered = len(slot_assignments)
+            slot_coverage = (slots_covered == 16384)
+            
+            if not slot_coverage:
+                logging.warning(f"Slot coverage incomplete: {slots_covered}/16384 slots covered by live nodes")
             
             return slot_coverage, conflicts
             

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -35,8 +35,8 @@ class StateValidator(IStateValidator):
             logging.error("No cluster connection provided")
             return self._create_failed_validation(start_time)
         
-        # Get current cluster nodes
-        current_nodes = cluster_connection.get_current_nodes()
+        # Get ALL cluster nodes (including failed ones) for accurate validation
+        current_nodes = cluster_connection.get_current_nodes(include_failed=True)
         if not current_nodes:
             logging.error("No nodes available in cluster")
             return self._create_failed_validation(start_time)
@@ -175,8 +175,10 @@ class StateValidator(IStateValidator):
             # Get cluster nodes to check for conflicts
             cluster_nodes = client.execute_command('CLUSTER', 'NODES')
             
-            # Parse slot assignments, but only from live nodes (not failed/disconnected)
+            # Parse slot assignments from ALL nodes, but track which are live
             slot_assignments: Dict[int, List[str]] = {}
+            live_node_ids: Set[str] = set()
+            
             for line in cluster_nodes.split('\n'):
                 if not line.strip():
                     continue
@@ -187,9 +189,10 @@ class StateValidator(IStateValidator):
                 node_id = parts[0]
                 flags = parts[2]
                 
-                # Skip failed or disconnected nodes - they shouldn't count for slot coverage
-                if 'fail' in flags or 'disconnected' in flags:
-                    continue
+                # Track live nodes
+                is_live = 'fail' not in flags and 'disconnected' not in flags
+                if is_live:
+                    live_node_ids.add(node_id)
                 
                 # Slots are in parts[8:]
                 for slot_range in parts[8:]:
@@ -199,32 +202,40 @@ class StateValidator(IStateValidator):
                         for slot in range(int(start), int(end) + 1):
                             if slot not in slot_assignments:
                                 slot_assignments[slot] = []
-                            slot_assignments[slot].append(node_id)
+                            slot_assignments[slot].append((node_id, is_live))
                     else:
                         # Single slot
                         try:
                             slot = int(slot_range)
                             if slot not in slot_assignments:
                                 slot_assignments[slot] = []
-                            slot_assignments[slot].append(node_id)
+                            slot_assignments[slot].append((node_id, is_live))
                         except ValueError:
                             pass
             
             client.close()
             
-            # Check for conflicts (multiple live nodes claiming same slot)
+            # Check for conflicts and slot coverage
             conflicts = []
-            for slot, nodes in slot_assignments.items():
-                if len(nodes) > 1:
-                    conflicts.append(SlotConflict(slot=slot, conflicting_nodes=nodes))
+            slots_covered_by_live_nodes = 0
             
-            # Slot coverage is good if all slots are assigned to live nodes
-            # Check that we have all 16384 slots covered by live nodes
-            slots_covered = len(slot_assignments)
-            slot_coverage = (slots_covered == 16384)
+            for slot, node_tuples in slot_assignments.items():
+                # Get live nodes for this slot
+                live_nodes_for_slot = [node_id for node_id, is_live in node_tuples if is_live]
+                
+                # Check for conflicts (multiple live nodes claiming same slot)
+                if len(live_nodes_for_slot) > 1:
+                    conflicts.append(SlotConflict(slot=slot, conflicting_nodes=live_nodes_for_slot))
+                
+                # Count slots covered by at least one live node
+                if len(live_nodes_for_slot) > 0:
+                    slots_covered_by_live_nodes += 1
+            
+            # Slot coverage is good if all 16384 slots are covered by live nodes
+            slot_coverage = (slots_covered_by_live_nodes == 16384)
             
             if not slot_coverage:
-                logging.warning(f"Slot coverage incomplete: {slots_covered}/16384 slots covered by live nodes")
+                logging.warning(f"Slot coverage incomplete: {slots_covered_by_live_nodes}/16384 slots covered by live nodes")
             
             return slot_coverage, conflicts
             
@@ -260,6 +271,11 @@ class StateValidator(IStateValidator):
         dead_replicas = []
         
         for replica in replica_nodes:
+            # Check if node is marked as failed in topology
+            if replica.get('status') == 'failed':
+                dead_replicas.append(f"{replica['host']}:{replica['port']}")
+                continue
+            
             try:
                 client = valkey.Valkey(
                     host=replica['host'],
@@ -332,6 +348,13 @@ class StateValidator(IStateValidator):
             connected_nodes = []
             
             for node in current_nodes:
+                node_addr = f"{node['host']}:{node['port']}"
+                
+                # Check if node is marked as failed in topology
+                if node.get('status') == 'failed':
+                    disconnected_nodes.append(node_addr)
+                    continue
+                
                 try:
                     client = valkey.Valkey(
                         host=node['host'],
@@ -341,11 +364,11 @@ class StateValidator(IStateValidator):
                     )
                     client.ping()
                     client.close()
-                    connected_nodes.append(f"{node['host']}:{node['port']}")
+                    connected_nodes.append(node_addr)
                 except Exception as e:
                     # Node is dead or unreachable - expected after chaos
-                    logging.debug(f"Node {node['host']}:{node['port']} unreachable: {e}")
-                    disconnected_nodes.append(f"{node['host']}:{node['port']}")
+                    logging.debug(f"Node {node_addr} unreachable: {e}")
+                    disconnected_nodes.append(node_addr)
             
             # After chaos, some nodes being dead is expected and acceptable
             # We consider connectivity good if at least one node per shard is reachable

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -151,12 +151,22 @@ class StateValidator(IStateValidator):
         if not current_nodes:
             return False, []
         
+        # Find a live node to query
+        live_node = None
+        for node in current_nodes:
+            if node.get('status') == 'connected':
+                live_node = node
+                break
+        
+        if not live_node:
+            logging.error("No live nodes available for slot validation")
+            return False, []
+        
         try:
-            # Connect to first live node to get cluster info
-            node = current_nodes[0]
+            # Connect to a live node to get cluster info
             client = valkey.Valkey(
-                host=node['host'],
-                port=node['port'],
+                host=live_node['host'],
+                port=live_node['port'],
                 socket_timeout=5,
                 decode_responses=True
             )

--- a/src/models.py
+++ b/src/models.py
@@ -280,14 +280,7 @@ class ClusterConnection:
     
     def get_current_nodes(self, include_failed: bool = True) -> List[Dict]:
         """
-        Get current cluster topology via CLUSTER NODES
-        
-        Args:
-            include_failed: If True, includes failed/disconnected nodes in the result.
-                          If False, only returns live nodes.
-        
-        Returns:
-            List of node dictionaries with keys: node_id, host, port, role, shard_id, status
+        Get current cluster topology via CLUSTER NODES. List of node dictionaries with keys: node_id, host, port, role, shard_id, status
         """
         # Build a mapping from port to shard_id using initial_nodes
         port_to_shard = {node.port: node.shard_id for node in self.initial_nodes}

--- a/src/models.py
+++ b/src/models.py
@@ -328,16 +328,18 @@ class ClusterConnection:
                     if not line.strip():
                         continue
                     parts = line.split()
-                    if len(parts) < 3:
+                    if len(parts) < 8:
                         continue
                     
                     node_id = parts[0]
                     flags = parts[2]
+                    link_state = parts[7] if len(parts) > 7 else 'connected'
                     host_port = parts[1].split('@')[0].split(':')
                     port = int(host_port[1])
                     
                     # Determine node status
-                    is_failed = 'fail' in flags or 'disconnected' in flags
+                    # Check for fail/fail? in flags AND disconnected link state
+                    is_failed = 'fail' in flags or link_state == 'disconnected'
                     status = 'failed' if is_failed else 'connected'
                     
                     # Skip failed/disconnected nodes if not requested

--- a/src/models.py
+++ b/src/models.py
@@ -278,10 +278,17 @@ class ClusterConnection:
     def __post_init__(self):
         self.startup_nodes = [{'host': '127.0.0.1', 'port': node.port} for node in self.initial_nodes]
     
-    def get_current_nodes(self) -> List[Dict]:
-        """Get current cluster topology via CLUSTER NODES"""
-        # Used for real-time cluster topology for chaos testing
+    def get_current_nodes(self, include_failed: bool = True) -> List[Dict]:
+        """
+        Get current cluster topology via CLUSTER NODES
         
+        Args:
+            include_failed: If True, includes failed/disconnected nodes in the result.
+                          If False, only returns live nodes.
+        
+        Returns:
+            List of node dictionaries with keys: node_id, host, port, role, shard_id, status
+        """
         # Build a mapping from port to shard_id using initial_nodes
         port_to_shard = {node.port: node.shard_id for node in self.initial_nodes}
         
@@ -315,12 +322,12 @@ class ClusterConnection:
                     if 'slave' in flags and len(parts) >= 4:
                         master_node_id = parts[3]
                         # We'll resolve this in second pass
-                        node_id_to_shard[node_id] = ('replica', master_node_id, port)
+                        node_id_to_shard[node_id] = ('replica', master_node_id, port, flags)
                     elif 'master' in flags:
                         # Primary nodes: use initial shard_id
                         if initial_shard_id is not None:
                             shard_to_primary_node_id[initial_shard_id] = node_id
-                            node_id_to_shard[node_id] = ('primary', initial_shard_id, port)
+                            node_id_to_shard[node_id] = ('primary', initial_shard_id, port, flags)
                 
                 # Second pass: resolve replica shards and build final node list
                 current_nodes = []
@@ -336,8 +343,12 @@ class ClusterConnection:
                     host_port = parts[1].split('@')[0].split(':')
                     port = int(host_port[1])
                     
-                    # Skip failed/disconnected nodes
-                    if 'fail' in flags or 'disconnected' in flags:
+                    # Determine node status
+                    is_failed = 'fail' in flags or 'disconnected' in flags
+                    status = 'failed' if is_failed else 'connected'
+                    
+                    # Skip failed/disconnected nodes if not requested
+                    if not include_failed and is_failed:
                         continue
                     
                     # Determine shard_id and role
@@ -368,12 +379,17 @@ class ClusterConnection:
                         'host': host_port[0],
                         'port': port,
                         'role': role,
-                        'shard_id': shard_id
+                        'shard_id': shard_id,
+                        'status': status
                     })
-                return current_nodes # list of dictionaries representing all nodes currently active in cluster
+                return current_nodes
             except Exception as e:
                 continue
         return []
+    
+    def get_live_nodes(self) -> List[Dict]:
+        """Get only live (connected) nodes from the cluster"""
+        return self.get_current_nodes(include_failed=False)
     
     def get_primary_nodes(self) -> List[Dict]:
         """Get current primary nodes"""

--- a/src/models.py
+++ b/src/models.py
@@ -287,28 +287,91 @@ class ClusterConnection:
         
         for node_info in self.startup_nodes:
             try:
-                client = valkey.Valkey(host=node_info['host'], port=node_info['port'])
+                client = valkey.Valkey(host=node_info['host'], port=node_info['port'], socket_timeout=2)
                 cluster_nodes_raw = client.execute_command('CLUSTER', 'NODES')
                 client.close()
                 
-                current_nodes = []
+                # First pass: build shard mapping from current topology
+                # This handles cases where failovers have changed which nodes are primaries
+                shard_to_primary_node_id = {}
+                node_id_to_shard = {}
+                
                 for line in cluster_nodes_raw.decode().strip().split('\n'):
+                    if not line.strip():
+                        continue
                     parts = line.split()
+                    if len(parts) < 8:
+                        continue
+                    
+                    node_id = parts[0]
+                    flags = parts[2]
                     host_port = parts[1].split('@')[0].split(':')
                     port = int(host_port[1])
                     
-                    # Get shard_id from our mapping
-                    shard_id = port_to_shard.get(port)
+                    # Get initial shard_id from port mapping
+                    initial_shard_id = port_to_shard.get(port)
+                    
+                    # For replicas, get shard from their master
+                    if 'slave' in flags and len(parts) >= 4:
+                        master_node_id = parts[3]
+                        # We'll resolve this in second pass
+                        node_id_to_shard[node_id] = ('replica', master_node_id, port)
+                    elif 'master' in flags:
+                        # Primary nodes: use initial shard_id
+                        if initial_shard_id is not None:
+                            shard_to_primary_node_id[initial_shard_id] = node_id
+                            node_id_to_shard[node_id] = ('primary', initial_shard_id, port)
+                
+                # Second pass: resolve replica shards and build final node list
+                current_nodes = []
+                for line in cluster_nodes_raw.decode().strip().split('\n'):
+                    if not line.strip():
+                        continue
+                    parts = line.split()
+                    if len(parts) < 3:
+                        continue
+                    
+                    node_id = parts[0]
+                    flags = parts[2]
+                    host_port = parts[1].split('@')[0].split(':')
+                    port = int(host_port[1])
+                    
+                    # Skip failed/disconnected nodes
+                    if 'fail' in flags or 'disconnected' in flags:
+                        continue
+                    
+                    # Determine shard_id and role
+                    if node_id in node_id_to_shard:
+                        node_info_tuple = node_id_to_shard[node_id]
+                        if node_info_tuple[0] == 'primary':
+                            role = 'primary'
+                            shard_id = node_info_tuple[1]
+                        else:  # replica
+                            role = 'replica'
+                            master_node_id = node_info_tuple[1]
+                            # Find shard_id from master
+                            shard_id = None
+                            if master_node_id in node_id_to_shard:
+                                master_info = node_id_to_shard[master_node_id]
+                                if master_info[0] == 'primary':
+                                    shard_id = master_info[1]
+                            # Fallback to port mapping
+                            if shard_id is None:
+                                shard_id = port_to_shard.get(port)
+                    else:
+                        # Fallback for nodes not in our mapping
+                        role = 'primary' if 'master' in flags else 'replica'
+                        shard_id = port_to_shard.get(port)
                     
                     current_nodes.append({
-                        'node_id': parts[0],
+                        'node_id': node_id,
                         'host': host_port[0],
                         'port': port,
-                        'role': 'primary' if 'master' in parts[2] else 'replica',
+                        'role': role,
                         'shard_id': shard_id
                     })
                 return current_nodes # list of dictionaries representing all nodes currently active in cluster
-            except:
+            except Exception as e:
                 continue
         return []
     

--- a/src/models.py
+++ b/src/models.py
@@ -338,8 +338,10 @@ class ClusterConnection:
                     port = int(host_port[1])
                     
                     # Determine node status
-                    # Check for fail/fail? in flags AND disconnected link state
-                    is_failed = 'fail' in flags or link_state == 'disconnected'
+                    # Check for explicit fail/fail? tokens (not substring match to avoid matching 'nofailover')
+                    flag_list = flags.split(',')
+                    has_fail_flag = 'fail' in flag_list or 'fail?' in flag_list
+                    is_failed = has_fail_flag or link_state == 'disconnected'
                     status = 'failed' if is_failed else 'connected'
                     
                     # Skip failed/disconnected nodes if not requested

--- a/tests/test_operation_orchestrator.py
+++ b/tests/test_operation_orchestrator.py
@@ -338,7 +338,7 @@ def test_execute_failover_exact_node_id_match():
     
     # Create mock cluster connection with node-1 and node-10
     mock_connection = Mock()
-    mock_connection.get_current_nodes.return_value = [
+    nodes_list = [
         {
             'node_id': 'node-1',
             'host': '127.0.0.1',
@@ -361,6 +361,8 @@ def test_execute_failover_exact_node_id_match():
             'shard_id': 2
         }
     ]
+    mock_connection.get_current_nodes.return_value = nodes_list
+    mock_connection.get_live_nodes.return_value = nodes_list
     
     orchestrator.set_cluster_connection(mock_connection)
     
@@ -394,7 +396,7 @@ def test_execute_failover_no_substring_false_positive():
     
     # Create mock cluster connection with only node-10, node-11, node-12
     mock_connection = Mock()
-    mock_connection.get_current_nodes.return_value = [
+    nodes_list = [
         {
             'node_id': 'node-10',
             'host': '127.0.0.1',
@@ -417,6 +419,8 @@ def test_execute_failover_no_substring_false_positive():
             'shard_id': 3
         }
     ]
+    mock_connection.get_current_nodes.return_value = nodes_list
+    mock_connection.get_live_nodes.return_value = nodes_list
     
     orchestrator.set_cluster_connection(mock_connection)
     
@@ -441,7 +445,7 @@ def test_execute_failover_shard_based_matching():
     
     # Create mock cluster connection with nodes having shard_id
     mock_connection = Mock()
-    mock_connection.get_current_nodes.return_value = [
+    nodes_list = [
         {
             'node_id': 'node-0',
             'host': '127.0.0.1',
@@ -464,6 +468,8 @@ def test_execute_failover_shard_based_matching():
             'shard_id': 10
         }
     ]
+    mock_connection.get_current_nodes.return_value = nodes_list
+    mock_connection.get_live_nodes.return_value = nodes_list
     
     orchestrator.set_cluster_connection(mock_connection)
     
@@ -500,7 +506,7 @@ def test_execute_failover_port_matching():
     
     # Create mock cluster connection
     mock_connection = Mock()
-    mock_connection.get_current_nodes.return_value = [
+    nodes_list = [
         {
             'node_id': 'abc123',
             'host': '127.0.0.1',
@@ -516,6 +522,8 @@ def test_execute_failover_port_matching():
             'shard_id': 1
         }
     ]
+    mock_connection.get_current_nodes.return_value = nodes_list
+    mock_connection.get_live_nodes.return_value = nodes_list
     
     orchestrator.set_cluster_connection(mock_connection)
     


### PR DESCRIPTION
The fix resolves the bug where operations were targeting dead nodes after failovers, making the fuzzer more reliable and the tests more reproducible