### PR TITLE
Query live nodes when choosing targets for chaos

### DIFF
--- a/src/chaos_engine/base.py
+++ b/src/chaos_engine/base.py
@@ -87,7 +87,7 @@ class BaseChaosEngine(IChaosEngine, ABC):
         # Future chaos types (like network chaos) might need active cleanup
         
         del self.active_chaos[chaos_id]
-        logger.info(f"Stopped chaos {chaos_id}")
+        logger.debug(f"Stopped chaos with chaos ID: {chaos_id}")
         return True
     
     def cleanup_chaos(self, cluster_id: str) -> bool:

--- a/src/cli.py
+++ b/src/cli.py
@@ -8,12 +8,13 @@ import sys
 import argparse
 import json
 import yaml
+import traceback
 from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime
 
 from .main import ClusterBusFuzzer
-from .fuzzer_engine import DSLLoader
+from .fuzzer_engine import DSLLoader, ScenarioGenerator
 from .models import ClusterConfig, ValidationConfig, WorkloadConfig, ExecutionResult, ValidationResult
 
 
@@ -59,6 +60,7 @@ class FuzzerCLI:
         else:
             print("Seed: Random")
         
+        # Default number of iterations is 1
         if args.iterations:
             print(f"Iterations: {args.iterations}")
         
@@ -86,7 +88,6 @@ class FuzzerCLI:
             except Exception as e:
                 print(f"Test failed with exception: {e}")
                 if args.verbose:
-                    import traceback
                     traceback.print_exc()
                 return 1
         
@@ -107,7 +108,7 @@ class FuzzerCLI:
         
         dsl_path = Path(args.file)
         if not dsl_path.exists():
-            print(f"[FAIL] DSL file not found: {args.file}")
+            print(f"DSL file not found: {args.file}")
             return 1
         
         try:
@@ -133,7 +134,6 @@ class FuzzerCLI:
         except Exception as e:
             print(f"DSL test failed: {e}")
             if args.verbose:
-                import traceback
                 traceback.print_exc()
             return 1
     
@@ -143,7 +143,7 @@ class FuzzerCLI:
         
         dsl_path = Path(args.file)
         if not dsl_path.exists():
-            print(f"[FAIL] DSL file not found: {args.file}")
+            print(f"DSL file not found: {args.file}")
             return 1
         
         try:
@@ -152,7 +152,6 @@ class FuzzerCLI:
             print("DSL file loaded successfully")
             
             # Parse and validate
-            from .fuzzer_engine import ScenarioGenerator
             generator = ScenarioGenerator()
             
             scenario = generator.parse_dsl_config(dsl_config.config_text)
@@ -183,7 +182,6 @@ class FuzzerCLI:
         except Exception as e:
             print(f"\nValidation Failed: {e}")
             if args.verbose:
-                import traceback
                 traceback.print_exc()
             return 1
     
@@ -214,7 +212,7 @@ class FuzzerCLI:
             print(f"Error: {result.error_message}")
     
     def _print_detailed_result(self, result: ExecutionResult):
-        """Print detailed test result"""
+        """Print detailed test result when --verbose flag is specified"""
         self._print_summary_result(result)
         
         # Print chaos events
@@ -282,10 +280,10 @@ class FuzzerCLI:
                 elif format == 'yaml':
                     yaml.dump(data, f, default_flow_style=False)
             
-            print(f"\n[PASS] Results saved to {output_path}")
+            print(f"\nResults saved to {output_path}")
             
         except Exception as e:
-            print(f"\n[FAIL] Failed to save results: {e}")
+            print(f"\nFailed to save results: {e}")
     
     def _result_to_dict(self, result: ExecutionResult) -> Dict[str, Any]:
         """Convert ExecutionResult to dictionary"""
@@ -318,7 +316,7 @@ Examples:
   # Run multiple iterations
   valkey-fuzzer random --iterations 10
   
-  # Run with configuration file
+  # Run with configuration file and store results to output file
   valkey-fuzzer random --config config.yaml --output results.json
   
   # Run DSL-based test
@@ -446,7 +444,6 @@ def main():
     except Exception as e:
         print(f"\nUnexpected error: {e}")
         if hasattr(args, 'verbose') and args.verbose:
-            import traceback
             traceback.print_exc()
         return 1
     

--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -14,10 +14,7 @@ import logging
 import time
 import random
 from typing import Optional, List
-from ..models import (
-    Operation, ChaosConfig, ChaosResult, NodeInfo, 
-    ProcessChaosType, ChaosType, TargetSelection
-)
+from ..models import Operation, ChaosConfig, ChaosResult, NodeInfo, ProcessChaosType, ChaosType, TargetSelection
 from ..chaos_engine.base import ProcessChaosEngine
 
 logging.basicConfig(format='%(levelname)-5s | %(filename)s:%(lineno)-3d | %(message)s', level=logging.INFO, force=True)
@@ -58,7 +55,8 @@ class ChaosCoordinator:
         self, 
         operation: Operation, 
         chaos_config: ChaosConfig,
-        cluster_nodes: List[NodeInfo]
+        cluster_nodes: List[NodeInfo],
+        cluster_connection=None
     ) -> List[ChaosResult]:
         """
         Coordinate chaos injection with a cluster operation based on timing configuration.
@@ -69,7 +67,7 @@ class ChaosCoordinator:
         
         try:
             # Select target node for chaos
-            target_node = self._select_chaos_target(cluster_nodes, chaos_config.target_selection)
+            target_node = self._select_chaos_target(cluster_nodes, chaos_config.target_selection, cluster_connection)
             
             if not target_node:
                 logger.warning("No suitable chaos target found")
@@ -119,11 +117,7 @@ class ChaosCoordinator:
         
         return chaos_results
     
-    def execute_chaos_during_operation(
-        self,
-        target_node: NodeInfo,
-        chaos_config: ChaosConfig
-    ) -> ChaosResult:
+    def execute_chaos_during_operation(self, target_node: NodeInfo, chaos_config: ChaosConfig) -> ChaosResult:
         """
         Execute chaos injection during operation execution.
         This is typically called by the operation orchestrator at the appropriate time.
@@ -147,11 +141,6 @@ class ChaosCoordinator:
             
             result = self.chaos_engine.inject_process_chaos(target_node, process_chaos_type)
             
-            if result.success:
-                logger.info(f"Successfully injected chaos on {target_node.node_id}")
-            else:
-                logger.error(f"Failed to inject chaos on {target_node.node_id}: {result.error_message}")
-            
             return result
         else:
             # Future chaos types (network chaos, etc.)
@@ -166,44 +155,66 @@ class ChaosCoordinator:
                 error_message=f"Unsupported chaos type: {chaos_config.chaos_type}"
             )
     
-    def _select_chaos_target(
-        self, 
-        cluster_nodes: List[NodeInfo], 
-        target_selection: TargetSelection
-    ) -> Optional[NodeInfo]:
+    def _select_chaos_target(self, cluster_nodes: List[NodeInfo], target_selection: TargetSelection, cluster_connection=None) -> Optional[NodeInfo]:
         """
         Select a target node for chaos injection based on selection strategy.
+        Uses live cluster topology to get accurate role information after failovers.
         """
         if not cluster_nodes:
             return None
+        
+        # Filter to only live nodes
+        live_nodes = [node for node in cluster_nodes if node.process and node.process.poll() is None]
+        
+        if not live_nodes:
+            logger.warning("No live nodes available for chaos injection")
+            return None
+        
+        # Get current cluster topology with updated roles if connection available
+        current_topology = None
+        if cluster_connection:
+            try:
+                current_topology = cluster_connection.get_live_nodes()
+            except Exception as e:
+                logger.debug(f"Could not get live topology: {e}")
         
         strategy = target_selection.strategy
         
         if strategy == "specific":
             # Select from specific nodes
             if target_selection.specific_nodes:
-                for node in cluster_nodes:
+                for node in live_nodes:
                     if node.node_id in target_selection.specific_nodes:
                         return node
             return None
         
         elif strategy == "primary_only":
-            # Select only from primary nodes
-            primary_nodes = [node for node in cluster_nodes if node.role == 'primary']
+            # Use current topology for accurate role information
+            if current_topology:
+                primary_ports = [n['port'] for n in current_topology if n['role'] == 'primary']
+                primary_nodes = [node for node in live_nodes if node.port in primary_ports]
+            else:
+                primary_nodes = [node for node in live_nodes if node.role == 'primary']
+            
             if primary_nodes:
                 return random.choice(primary_nodes)
             return None
         
         elif strategy == "replica_only":
-            # Select only from replica nodes
-            replica_nodes = [node for node in cluster_nodes if node.role == 'replica']
+            # Use current topology for accurate role information
+            if current_topology:
+                replica_ports = [n['port'] for n in current_topology if n['role'] == 'replica']
+                replica_nodes = [node for node in live_nodes if node.port in replica_ports]
+            else:
+                replica_nodes = [node for node in live_nodes if node.role == 'replica']
+            
             if replica_nodes:
                 return random.choice(replica_nodes)
             return None
         
         elif strategy == "random":
-            # Select randomly from all nodes
-            return random.choice(cluster_nodes)
+            # Select randomly from all live nodes
+            return random.choice(live_nodes)
         
         else:
             logger.warning(f"Unknown target selection strategy: {strategy}")

--- a/src/fuzzer_engine/cluster_coordinator.py
+++ b/src/fuzzer_engine/cluster_coordinator.py
@@ -4,12 +4,8 @@ Cluster Coordinator - Manages cluster lifecycle and interfaces with Cluster Orch
 import logging
 import time
 from typing import List, Optional
-from ..models import (
-    ClusterConfig, ClusterInstance, ClusterStatus, NodeInfo, ClusterConnection
-)
-from ..cluster_orchestrator.orchestrator import (
-    ConfigurationManager, ClusterManager, PortManager
-)
+from ..models import ClusterConfig, ClusterInstance, ClusterStatus, NodeInfo, ClusterConnection
+from ..cluster_orchestrator.orchestrator import ConfigurationManager, ClusterManager, PortManager
 
 logging.basicConfig(format='%(levelname)-5s | %(filename)s:%(lineno)-3d | %(message)s', level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -18,6 +18,9 @@ from .error_handler import ErrorHandler, ErrorContext, ErrorCategory, ErrorSever
 logging.basicConfig(format='%(levelname)-5s | %(filename)s:%(lineno)-3d | %(message)s', level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
+cli_logger = logging.getLogger('cli')
+cli_logger.addHandler(logging.StreamHandler())
+cli_logger.propagate = False
 
 class FuzzerEngine(IFuzzerEngine):
     """
@@ -35,7 +38,7 @@ class FuzzerEngine(IFuzzerEngine):
         self.logger = FuzzerLogger()
         self.error_handler = ErrorHandler()
         
-        logger.info("Fuzzer Engine initialized")
+        logger.info("Fuzzer Engine Initialized")
     
     def generate_random_scenario(self, seed: Optional[int] = None) -> Scenario:
         """Generate a randomized test scenario with optional seed for reproducibility."""
@@ -124,13 +127,13 @@ class FuzzerEngine(IFuzzerEngine):
                 self.logger.log_cluster_state_snapshot(cluster_status, "initial_state")
             
             # Step 2: Validate cluster readiness
-            print()
+            cli_logger.info("")
             logger.info("Step 2: Validating cluster readiness")
             if not self._validate_cluster_readiness_with_retry(cluster_instance.cluster_id):
                 raise Exception("Cluster failed readiness validation")
             
             # Step 3: Load test data
-            print()
+            cli_logger.info("")
             logger.info("Step 3: Loading test data")
             self._load_test_data(cluster_connection)
             
@@ -140,7 +143,7 @@ class FuzzerEngine(IFuzzerEngine):
             self.operation_orchestrator.set_cluster_connection(cluster_connection)
             
             # Step 4: Execute operations with chaos coordination
-            print()
+            cli_logger.info("")
             logger.info(f"Step 4: Executing {len(scenario.operations)} operations")
             
             for i, operation in enumerate(scenario.operations):
@@ -159,7 +162,8 @@ class FuzzerEngine(IFuzzerEngine):
                     operation_chaos_events = self.chaos_coordinator.coordinate_chaos_with_operation(
                         operation,
                         scenario.chaos_config,
-                        cluster_instance.nodes
+                        cluster_instance.nodes,
+                        cluster_connection
                     )
                     chaos_events.extend(operation_chaos_events)
                     
@@ -211,7 +215,7 @@ class FuzzerEngine(IFuzzerEngine):
                     # Continue with next operation (graceful degradation)
             
             # Step 5: Final cluster validation
-            print()
+            cli_logger.info("")
             logger.info("Step 5: Final cluster validation")
             final_validation = self.state_validator.validate_cluster_state(
                 cluster_instance.cluster_id,

--- a/tests/test_chaos_coordinator.py
+++ b/tests/test_chaos_coordinator.py
@@ -11,6 +11,14 @@ from src.models import (
 )
 
 
+@pytest.fixture
+def mock_live_process():
+    """Create a mock process that appears alive (poll returns None)"""
+    mock = Mock()
+    mock.poll.return_value = None
+    return mock
+
+
 def test_chaos_coordinator_initialization():
     """Test chaos coordinator initialization"""
     coordinator = ChaosCoordinator()
@@ -58,7 +66,7 @@ def test_register_cluster_nodes():
     assert coordinator.chaos_engine.node_processes["node-1"] == 12346
 
 
-def test_select_chaos_target_random():
+def test_select_chaos_target_random(mock_live_process):
     """Test selecting chaos target with random strategy"""
     coordinator = ChaosCoordinator()
     
@@ -70,7 +78,7 @@ def test_select_chaos_target_random():
             port=7000,
             bus_port=17000,
             pid=12345,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         ),
@@ -81,20 +89,20 @@ def test_select_chaos_target_random():
             port=7001,
             bus_port=17001,
             pid=12346,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         )
     ]
     
     target_selection = TargetSelection(strategy="random")
-    target = coordinator._select_chaos_target(nodes, target_selection)
+    target = coordinator._select_chaos_target(nodes, target_selection, None)
     
     assert target is not None
     assert target.node_id in ["node-0", "node-1"]
 
 
-def test_select_chaos_target_primary_only():
+def test_select_chaos_target_primary_only(mock_live_process):
     """Test selecting chaos target with primary_only strategy"""
     coordinator = ChaosCoordinator()
     
@@ -106,7 +114,7 @@ def test_select_chaos_target_primary_only():
             port=7000,
             bus_port=17000,
             pid=12345,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         ),
@@ -117,21 +125,21 @@ def test_select_chaos_target_primary_only():
             port=7001,
             bus_port=17001,
             pid=12346,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         )
     ]
     
     target_selection = TargetSelection(strategy="primary_only")
-    target = coordinator._select_chaos_target(nodes, target_selection)
+    target = coordinator._select_chaos_target(nodes, target_selection, None)
     
     assert target is not None
     assert target.node_id == "node-0"
     assert target.role == "primary"
 
 
-def test_select_chaos_target_replica_only():
+def test_select_chaos_target_replica_only(mock_live_process):
     """Test selecting chaos target with replica_only strategy"""
     coordinator = ChaosCoordinator()
     
@@ -143,7 +151,7 @@ def test_select_chaos_target_replica_only():
             port=7000,
             bus_port=17000,
             pid=12345,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         ),
@@ -154,21 +162,21 @@ def test_select_chaos_target_replica_only():
             port=7001,
             bus_port=17001,
             pid=12346,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         )
     ]
     
     target_selection = TargetSelection(strategy="replica_only")
-    target = coordinator._select_chaos_target(nodes, target_selection)
+    target = coordinator._select_chaos_target(nodes, target_selection, None)
     
     assert target is not None
     assert target.node_id == "node-1"
     assert target.role == "replica"
 
 
-def test_select_chaos_target_specific():
+def test_select_chaos_target_specific(mock_live_process):
     """Test selecting chaos target with specific strategy"""
     coordinator = ChaosCoordinator()
     
@@ -180,7 +188,7 @@ def test_select_chaos_target_specific():
             port=7000,
             bus_port=17000,
             pid=12345,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         ),
@@ -191,14 +199,14 @@ def test_select_chaos_target_specific():
             port=7001,
             bus_port=17001,
             pid=12346,
-            process=Mock(),
+            process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
         )
     ]
     
     target_selection = TargetSelection(strategy="specific", specific_nodes=["node-1"])
-    target = coordinator._select_chaos_target(nodes, target_selection)
+    target = coordinator._select_chaos_target(nodes, target_selection, None)
     
     assert target is not None
     assert target.node_id == "node-1"
@@ -209,7 +217,7 @@ def test_select_chaos_target_empty_nodes():
     coordinator = ChaosCoordinator()
     
     target_selection = TargetSelection(strategy="random")
-    target = coordinator._select_chaos_target([], target_selection)
+    target = coordinator._select_chaos_target([], target_selection, None)
     
     assert target is None
 
@@ -233,7 +241,7 @@ def test_select_chaos_target_no_primary():
     ]
     
     target_selection = TargetSelection(strategy="primary_only")
-    target = coordinator._select_chaos_target(nodes, target_selection)
+    target = coordinator._select_chaos_target(nodes, target_selection, None)
     
     assert target is None
 
@@ -329,7 +337,7 @@ def test_coordinate_chaos_with_operation_no_target(mock_sleep):
     )
     
     # Empty node list - no target will be found
-    results = coordinator.coordinate_chaos_with_operation(operation, chaos_config, [])
+    results = coordinator.coordinate_chaos_with_operation(operation, chaos_config, [], None)
     
     assert len(results) == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,11 +258,11 @@ class TestFuzzerCLI:
         assert "not found" in captured.out
     
     @patch('src.cli.DSLLoader')
-    @patch('src.fuzzer_engine.ScenarioGenerator')
+    @patch('src.cli.ScenarioGenerator')
     def test_validate_dsl_success(self, mock_generator_class, mock_loader, tmp_path, capsys):
         """Test validating DSL configuration"""
         dsl_file = tmp_path / "test.yaml"
-        dsl_file.write_text("scenario:\n  id: test\n")
+        dsl_file.write_text("scenario_id: test\ncluster:\n  num_shards: 3\n  replicas_per_shard: 1\noperations:\n  - type: failover\n    target_node: node-0\n")
         
         mock_dsl_config = Mock(config_text="test config")
         mock_loader.load_from_file.return_value = mock_dsl_config


### PR DESCRIPTION
**__Changes made__**
- Utilize static ports in order to resolve #44 
- Updated test cases to handle mock node connections when querying the cluster. Also fixed DSL Test
- Removed duplicate logging and switch some info logs to debug logs
- Removed duplicate imports

