### PR TITLE
Fixing Minor Daily Test Failures

### DIFF
--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -207,30 +207,17 @@ class ChaosCoordinator:
             ])
             logger.info(f"Randomized chaos type: {randomized_config.process_chaos_type.value}")
 
-        # Randomize chaos timing coordination (30% chance for each timing option)
-        # At least one must be True
-        chaos_before = self.rng.random() < 0.3
-        chaos_during = self.rng.random() < 0.5  # Higher probability for during
-        chaos_after = self.rng.random() < 0.3
-
-        # Ensure at least one is True
-        if not (chaos_before or chaos_during or chaos_after):
-            chaos_during = True
+        # Randomize chaos timing coordination - select exactly ONE timing option
+        timing_options = ['before', 'during', 'after']
+        selected_timing = self.rng.choice(timing_options)
 
         randomized_config.coordination = ChaosCoordination(
-            chaos_before_operation=chaos_before,
-            chaos_during_operation=chaos_during,
-            chaos_after_operation=chaos_after
+            chaos_before_operation=(selected_timing == 'before'),
+            chaos_during_operation=(selected_timing == 'during'),
+            chaos_after_operation=(selected_timing == 'after')
         )
 
-        timing_desc = []
-        if chaos_before:
-            timing_desc.append("before")
-        if chaos_during:
-            timing_desc.append("during")
-        if chaos_after:
-            timing_desc.append("after")
-        logger.info(f"Randomized chaos timing: {', '.join(timing_desc)}")
+        logger.info(f"Randomized chaos timing: {selected_timing}")
 
         # Randomize target selection strategy (if not specific nodes)
         if randomized_config.target_selection.strategy != "specific":


### PR DESCRIPTION
Fixed two bugs that showed up multiple times in the daily test failures

**Bug 1: Multiple Chaos Injections Per Operation**

The chaos coordinator was selecting multiple timing options (before, during, after) simultaneously, causing the same node to be killed multiple times per operation. This led to the same node being killed 2-3 times in rapid succession, an increased probability of killing both primary and replica of a shard, and loss of cluster quorum.

Example from logs

```
INFO  | chaos_coordinator.py:233 | Randomized chaos timing: before, during
INFO  | chaos_coordinator.py:106 | Injecting chaos before operation
INFO  | chaos_coordinator.py:273 | Injecting sigkill on node-1
INFO  | chaos_coordinator.py:117 | Injecting chaos during operation execution
INFO  | chaos_coordinator.py:273 | Injecting sigkill on node-1 
```

As seen above the same node was killed twice which is unnecessary and can lead to failures.

**Bug 2: False Failures for Replicas Killed by Chaos**

In our validator, we were incorrectly flagging disconnected replicas as critical failures even when they were intentionally killed by chaos injection. This caused valid chaos scenarios to be reported as test failures.