### PR TITLE
Fix Topology Validation Errors

### DIFF
--- a/.github/workflows/fuzzer-run.yml
+++ b/.github/workflows/fuzzer-run.yml
@@ -2,9 +2,9 @@ name: Daily Valkey Fuzzer
 
 on:
   schedule:
-    # Run every 2 hours
-    - cron: '0 */1 * * *'
-  workflow_dispatch:  # Allow manual triggering
+    # Run every 4 hours
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
 
 jobs:
   random-fuzzer:

--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -242,6 +242,9 @@ class ChaosCoordinator:
             log.info(f"Injecting {process_chaos_type.value} on {target_node.node_id}")
             
             result = self.chaos_engine.inject_process_chaos(target_node, process_chaos_type, log_buffer=log)
+            
+            # Capture role at time of kill for topology validation
+            result.target_role = target_node.role
 
             return result
         else:

--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -140,7 +140,7 @@ class ChaosCoordinator:
         return chaos_results
     
     def _convert_dict_nodes_to_nodeinfo(self, live_nodes_dict: List[dict], initial_nodes: List[NodeInfo]) -> List[NodeInfo]:
-        """Convert dictionary node representations to NodeInfo objects."""
+        """Convert dictionary node representations to NodeInfo objects with live roles."""
         node_info_list = []
         for node_dict in live_nodes_dict:
             # Find matching initial node to get full info
@@ -151,6 +151,7 @@ class ChaosCoordinator:
                 None
             )
             if matching_node:
+                matching_node.role = node_dict.get('role', matching_node.role)
                 node_info_list.append(matching_node)
             else:
                 # Create a basic NodeInfo from the dict if no match found

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -185,11 +185,12 @@ class FuzzerEngine(IFuzzerEngine):
             for chaos_event in chaos_events:
                 if chaos_event.success and chaos_event.chaos_type == ChaosType.PROCESS_KILL:
                     target_node_id = chaos_event.target_node
+                    target_role = chaos_event.target_role
                     for node in cluster_instance.nodes:
                         if node.node_id == target_node_id:
                             node_address = f"{node.host}:{node.port}"
-                            state_validator.register_killed_node(node_address)
-                            logger.info(f"Registered killed node for validation: {node_address}")
+                            state_validator.register_killed_node(node_address, target_role)
+                            logger.info(f"Registered killed node for validation: {node_address} (role: {target_role})")
                             break
             
             # Step 5: Final cluster validation

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -80,7 +80,8 @@ class ParallelExecutor:
                             target_node,
                             deferred['chaos_config'],
                             deferred['should_randomize'],
-                            buffer
+                            buffer,
+                            cluster_connection
                         )
                         immediate_chaos.append(result)
                         # Record deferred chaos in history

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -66,8 +66,18 @@ class ParallelExecutor:
                     for deferred in deferred_chaos:
                         buffer.info(f"Injecting deferred chaos after operation (delay: {deferred['delay']:.2f}s)")
                         time.sleep(deferred['delay'])
+                        
+                        target_node = deferred['target_node']
+                        live_nodes_dict = cluster_connection.get_live_nodes()
+                        if live_nodes_dict:
+                            for node_dict in live_nodes_dict:
+                                if node_dict['node_id'] == target_node.cluster_node_id:
+                                    target_node.role = node_dict.get('role', target_node.role)
+                                    buffer.debug(f"Refreshed target node role to: {target_node.role}")
+                                    break
+                        
                         result = self.chaos_coordinator._inject_chaos(
-                            deferred['target_node'],
+                            target_node,
                             deferred['chaos_config'],
                             deferred['should_randomize'],
                             buffer

--- a/src/models.py
+++ b/src/models.py
@@ -197,6 +197,7 @@ class ChaosResult:
     start_time: float
     end_time: Optional[float] = None
     error_message: Optional[str] = None
+    target_role: Optional[str] = None
 
 
 @dataclass

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -90,7 +90,7 @@ def test_full_cluster_creation():
         expected_configs = {
             'protected-mode': 'no',
             'cluster-enabled': 'yes',
-            'cluster-node-timeout': '1000',
+            'cluster-node-timeout': '5000',
             'appendonly': 'yes', 
             'save': '',
             'cluster-require-full-coverage': 'no',

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -90,7 +90,7 @@ def test_full_cluster_creation():
         expected_configs = {
             'protected-mode': 'no',
             'cluster-enabled': 'yes',
-            'cluster-node-timeout': '5000',
+            'cluster-node-timeout': '1000',
             'appendonly': 'yes', 
             'save': '',
             'cluster-require-full-coverage': 'no',


### PR DESCRIPTION
This daily run failure exposed a bug in our topology validation. Originally, we only saw false positive failures when nodes changed roles between cluster formation and chaos injection. For example, when a node was promoted to a primary, and then chaos subsequently killed that node, the validation incorrectly counted the killed node by it's original role (replica) instead of its role at the time of death (primary).

https://github.com/valkey-io/valkey-fuzzer/actions/runs/20698361419/job/59416937272