### PR TITLE
Prevent Loss of Cluster Quorum Due to Chaos Operations

### DIFF
--- a/.github/workflows/test-pr-2227.yml
+++ b/.github/workflows/test-pr-2227.yml
@@ -30,6 +30,7 @@ jobs:
         git fetch --depth 1 origin pull/2227/head:pr-2227
         git checkout pr-2227
         make -j$(nproc)
+        sudo make install PREFIX=/usr/local
         mv /tmp/valkey-pr /tmp/valkey-build/valkey
     
     - name: Install fuzzer dependencies

--- a/src/fuzzer_engine/test_case_generator.py
+++ b/src/fuzzer_engine/test_case_generator.py
@@ -99,8 +99,6 @@ class ScenarioGenerator(ITestCaseGenerator):
             chaos_duration=random.uniform(5, 15)
         )
         
-        # If primary_only strategy, force chaos_after_operation to prevent simultaneous
-        # primary kills during parallel operations which would cause quorum loss
         if strategy == "primary_only":
             coordination = ChaosCoordination(
                 chaos_before_operation=False,

--- a/src/fuzzer_engine/test_case_generator.py
+++ b/src/fuzzer_engine/test_case_generator.py
@@ -99,13 +99,22 @@ class ScenarioGenerator(ITestCaseGenerator):
             chaos_duration=random.uniform(5, 15)
         )
         
-        chaos_phases = [
-            {"chaos_before_operation": True, "chaos_during_operation": False, "chaos_after_operation": False},
-            {"chaos_before_operation": False, "chaos_during_operation": True, "chaos_after_operation": False},
-            {"chaos_before_operation": False, "chaos_during_operation": False, "chaos_after_operation": True},
-        ]
-        selected_phase = random.choice(chaos_phases)
-        coordination = ChaosCoordination(**selected_phase)
+        # If primary_only strategy, force chaos_after_operation to prevent simultaneous
+        # primary kills during parallel operations which would cause quorum loss
+        if strategy == "primary_only":
+            coordination = ChaosCoordination(
+                chaos_before_operation=False,
+                chaos_during_operation=False,
+                chaos_after_operation=True
+            )
+        else:
+            chaos_phases = [
+                {"chaos_before_operation": True, "chaos_during_operation": False, "chaos_after_operation": False},
+                {"chaos_before_operation": False, "chaos_during_operation": True, "chaos_after_operation": False},
+                {"chaos_before_operation": False, "chaos_during_operation": False, "chaos_after_operation": True},
+            ]
+            selected_phase = random.choice(chaos_phases)
+            coordination = ChaosCoordination(**selected_phase)
         
         process_chaos_type = random.choice([ProcessChaosType.SIGKILL, ProcessChaosType.SIGTERM])
         


### PR DESCRIPTION
We have seen scenarios where the fuzzer tests will fail due to loss of cluster quorum. This change makes it so if we only inject chaos after the operations if the chaos strategy chosen is "primary_only" 