### PR TITLE
Add PR-triggered fuzzer workflow with strict validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles

--- a/.github/workflows/pr-merge-fuzzer.yml
+++ b/.github/workflows/pr-merge-fuzzer.yml
@@ -1,0 +1,429 @@
+name: PR Merge Valkey Fuzzer
+
+on:
+  workflow_call:
+    inputs:
+      fuzzer_ref:
+        description: Ref of this repo to check out when called from another repo
+        required: false
+        type: string
+        default: main
+      valkey_repository:
+        description: Repository containing the Valkey PR to test
+        required: false
+        type: string
+        default: valkey-io/valkey
+      valkey_ref:
+        description: Ref to build and test, for example refs/pull/123/merge
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number, used only for summaries
+        required: false
+        type: string
+        default: ""
+      pr_url:
+        description: Pull request URL, used only for summaries
+        required: false
+        type: string
+        default: ""
+      label_name:
+        description: Trigger label, used only for summaries
+        required: false
+        type: string
+        default: run-fuzzer
+      run_count:
+        description: Number of random fuzzer runs to queue
+        required: false
+        type: number
+        default: 10
+  workflow_dispatch:
+    inputs:
+      fuzzer_ref:
+        description: Ref of this repo to check out
+        required: false
+        type: string
+        default: main
+      valkey_repository:
+        description: Repository containing the Valkey commit to test
+        required: false
+        type: string
+        default: valkey-io/valkey
+      valkey_ref:
+        description: Ref to build and test, for example refs/pull/123/merge
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number, used only for summaries
+        required: false
+        type: string
+        default: ""
+      pr_url:
+        description: Pull request URL, used only for summaries
+        required: false
+        type: string
+        default: ""
+      label_name:
+        description: Trigger label, used only for summaries
+        required: false
+        type: string
+        default: run-fuzzer
+      run_count:
+        description: Number of random fuzzer runs to queue
+        required: false
+        type: number
+        default: 10
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-merge-fuzzer-${{ inputs.valkey_repository }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runs: ${{ steps.matrix.outputs.runs }}
+    steps:
+      - name: Build matrix
+        id: matrix
+        env:
+          RUN_COUNT: ${{ inputs.run_count }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          run_count = int(float(os.environ["RUN_COUNT"]))
+          runs = [{"run_id": run_id} for run_id in range(1, run_count + 1)]
+          print(f"runs={json.dumps(runs)}")
+          PY
+
+  build-valkey:
+    name: Build Valkey
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      resolved_sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - name: Checkout Valkey
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.valkey_repository }}
+          ref: ${{ inputs.valkey_ref }}
+          fetch-depth: 1
+          path: valkey-src
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libssl-dev tcl
+
+      - name: Build Valkey
+        working-directory: valkey-src
+        run: make -j"$(nproc)"
+
+      - name: Capture resolved SHA
+        id: commit
+        working-directory: valkey-src
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Valkey binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: valkey-pr-binaries
+          if-no-files-found: error
+          path: |
+            valkey-src/src/valkey-server
+            valkey-src/src/valkey-cli
+            valkey-src/src/valkey-benchmark
+
+  random-fuzzer:
+    name: Random fuzzer run ${{ matrix.run_id }}
+    needs:
+      - prepare-matrix
+      - build-valkey
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.runs) }}
+    steps:
+      - name: Checkout valkey-fuzzer
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'workflow_call' && 'sarthakaggarwal97/valkey-fuzzer' || github.repository }}
+          ref: ${{ github.event_name == 'workflow_call' && inputs.fuzzer_ref || github.sha }}
+
+      - name: Download Valkey binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: valkey-pr-binaries
+          path: ${{ runner.temp }}/valkey-binaries
+
+      - name: Restore executable bits
+        run: chmod +x "${{ runner.temp }}/valkey-binaries/"*
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Execute fuzzer run
+        id: execute
+        continue-on-error: true
+        env:
+          RUN_ID: ${{ matrix.run_id }}
+          RUN_ROOT: ${{ runner.temp }}/pr-merge-fuzzer
+          VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
+        run: |
+          set +e
+
+          artifact_dir="${RUN_ROOT}/run-${RUN_ID}"
+          mkdir -p "${artifact_dir}"
+          exit_code=0
+          status=success
+          stage=setup
+
+          python -m pip install --upgrade pip
+          pip_exit=$?
+          if [ "${pip_exit}" -ne 0 ]; then
+            exit_code="${pip_exit}"
+            status=failure
+            stage=pip-upgrade
+          fi
+
+          if [ "${status}" = "success" ]; then
+            pip install pytest pytest-asyncio
+            pip_deps_exit=$?
+            if [ "${pip_deps_exit}" -ne 0 ]; then
+              exit_code="${pip_deps_exit}"
+              status=failure
+              stage=python-dependencies
+            fi
+          fi
+
+          if [ "${status}" = "success" ] && [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+            requirements_exit=$?
+            if [ "${requirements_exit}" -ne 0 ]; then
+              exit_code="${requirements_exit}"
+              status=failure
+              stage=requirements
+            fi
+          fi
+
+          if [ "${status}" = "success" ]; then
+            pip install -e .
+            editable_exit=$?
+            if [ "${editable_exit}" -ne 0 ]; then
+              exit_code="${editable_exit}"
+              status=failure
+              stage=package-install
+            fi
+          fi
+
+          if [ "${status}" = "success" ]; then
+            stage=fuzzer
+            valkey-fuzzer cluster \
+              --random \
+              --verbose \
+              --valkey-binary "${VALKEY_BINARY}" \
+              --output "${artifact_dir}/result.json" \
+              --format json \
+              2>&1 | tee "${artifact_dir}/console.log"
+            fuzzer_exit=${PIPESTATUS[0]}
+            if [ "${fuzzer_exit}" -ne 0 ]; then
+              exit_code="${fuzzer_exit}"
+              status=failure
+            fi
+          fi
+
+          if [ -d "/tmp/valkey-fuzzer/logs" ]; then
+            cp -R /tmp/valkey-fuzzer/logs "${artifact_dir}/node-logs"
+          fi
+
+          export EXIT_CODE="${exit_code}"
+          export STATUS="${status}"
+          export STAGE="${stage}"
+
+          python - <<'PY'
+          import json
+          import os
+
+          artifact_dir = os.path.join(os.environ["RUN_ROOT"], f"run-{os.environ['RUN_ID']}")
+          result_path = os.path.join(artifact_dir, "result.json")
+
+          metadata = {
+              "run_id": int(os.environ["RUN_ID"]),
+              "status": os.environ["STATUS"],
+              "stage": os.environ["STAGE"],
+              "exit_code": int(os.environ["EXIT_CODE"]),
+              "scenario_id": None,
+              "seed": None,
+              "result_success": None,
+              "duration": None,
+              "post_operation_validation_failures": 0,
+              "final_failed_checks": [],
+              "error_message": None,
+          }
+
+          if os.path.exists(result_path):
+              with open(result_path, "r", encoding="utf-8") as handle:
+                  result_payload = json.load(handle)
+
+              results = result_payload.get("results", [])
+              if results:
+                  first_result = results[0]
+                  metadata["scenario_id"] = first_result.get("scenario_id")
+                  metadata["seed"] = first_result.get("seed")
+                  metadata["result_success"] = first_result.get("success")
+                  metadata["duration"] = first_result.get("duration")
+                  metadata["post_operation_validation_failures"] = sum(
+                      1
+                      for validation in first_result.get("per_operation_validations", [])
+                      if not validation.get("overall_success", False)
+                  )
+                  metadata["final_failed_checks"] = (
+                      first_result.get("final_validation", {}).get("failed_checks", [])
+                  )
+                  metadata["error_message"] = first_result.get("error_message")
+
+          with open(os.path.join(artifact_dir, "metadata.json"), "w", encoding="utf-8") as handle:
+              json.dump(metadata, handle, indent=2)
+          PY
+
+          echo "EXIT_CODE=${exit_code}" >> "$GITHUB_ENV"
+          echo "STATUS=${status}" >> "$GITHUB_ENV"
+          echo "STAGE=${stage}" >> "$GITHUB_ENV"
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "stage=${stage}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: valkey-pr-fuzzer-run-${{ matrix.run_id }}
+          if-no-files-found: error
+          path: ${{ runner.temp }}/pr-merge-fuzzer/run-${{ matrix.run_id }}
+
+      - name: Mark job as failed when the fuzzer run fails
+        if: steps.execute.outputs.exit_code != '0'
+        run: exit 1
+
+  summarize:
+    name: Summarize PR fuzzer results
+    if: ${{ always() }}
+    needs:
+      - build-valkey
+      - random-fuzzer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download run artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: valkey-pr-fuzzer-run-*
+          path: collected-results
+
+      - name: Write workflow summary
+        env:
+          BUILD_RESULT: ${{ needs.build-valkey.result }}
+          RESOLVED_SHA: ${{ needs.build-valkey.outputs.resolved_sha }}
+          RUN_COUNT: ${{ inputs.run_count }}
+          VALKEY_REPOSITORY: ${{ inputs.valkey_repository }}
+          VALKEY_REF: ${{ inputs.valkey_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_URL: ${{ inputs.pr_url }}
+          LABEL_NAME: ${{ inputs.label_name }}
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import os
+          import sys
+
+          run_count = int(float(os.environ["RUN_COUNT"]))
+          build_result = os.environ["BUILD_RESULT"]
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+
+          metadata_paths = sorted(
+              glob.glob("collected-results/**/metadata.json", recursive=True)
+          )
+
+          run_results = {}
+          for metadata_path in metadata_paths:
+              with open(metadata_path, "r", encoding="utf-8") as handle:
+                  metadata = json.load(handle)
+              run_results[int(metadata["run_id"])] = metadata
+
+          missing_runs = [
+              run_id for run_id in range(1, run_count + 1)
+              if run_id not in run_results
+          ]
+
+          passed_runs = sum(1 for result in run_results.values() if result["status"] == "success")
+          failed_runs = sum(1 for result in run_results.values() if result["status"] != "success")
+          overall_failed = build_result != "success" or failed_runs > 0 or bool(missing_runs)
+
+          pr_line = ""
+          if os.environ["PR_NUMBER"]:
+              if os.environ["PR_URL"]:
+                  pr_line = f"- PR: [#{os.environ['PR_NUMBER']}]({os.environ['PR_URL']})\n"
+              else:
+                  pr_line = f"- PR: #{os.environ['PR_NUMBER']}\n"
+
+          lines = [
+              "## PR Merge Valkey Fuzzer",
+              "",
+              f"- Valkey repository: `{os.environ['VALKEY_REPOSITORY']}`",
+              f"- Requested ref: `{os.environ['VALKEY_REF']}`",
+              f"- Resolved SHA: `{os.environ['RESOLVED_SHA'] or 'unavailable'}`",
+              f"- Trigger label: `{os.environ['LABEL_NAME']}`",
+          ]
+
+          if pr_line:
+              lines.append(pr_line.rstrip())
+
+          lines.extend([
+              f"- Passed runs: {passed_runs}/{run_count}",
+              f"- Failed runs: {failed_runs}",
+              f"- Missing run artifacts: {len(missing_runs)}",
+              "",
+              "| Run | Status | Seed | Stage | Duration (s) | Post-op Failures | Final Checks | Error |",
+              "| --- | --- | --- | --- | --- | --- | --- | --- |",
+          ])
+
+          for run_id in range(1, run_count + 1):
+              result = run_results.get(run_id)
+              if result is None:
+                  lines.append(f"| {run_id} | missing | - | artifact | - | artifact not uploaded |")
+                  continue
+
+              error = result.get("error_message") or "-"
+              error = str(error).replace("\n", " ").replace("|", "/")
+              seed = result.get("seed") if result.get("seed") is not None else "-"
+              duration = result.get("duration") if result.get("duration") is not None else "-"
+              post_op_failures = result.get("post_operation_validation_failures", 0)
+              final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
+              final_checks = final_checks.replace("|", "/")
+              lines.append(
+                  f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {duration} | {post_op_failures} | {final_checks} | {error} |"
+              )
+
+          if missing_runs:
+              lines.extend([
+                  "",
+                  f"Missing artifacts for runs: {', '.join(str(run_id) for run_id in missing_runs)}",
+              ])
+
+          with open(summary_path, "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+
+          if overall_failed:
+              sys.exit(1)
+          PY

--- a/.github/workflows/pr-merge-fuzzer.yml
+++ b/.github/workflows/pr-merge-fuzzer.yml
@@ -33,7 +33,7 @@ on:
         type: string
         default: run-fuzzer
       run_count:
-        description: Number of random fuzzer runs to queue
+        description: Positive integer number of random fuzzer runs to queue
         required: false
         type: number
         default: 10
@@ -69,7 +69,7 @@ on:
         type: string
         default: run-fuzzer
       run_count:
-        description: Number of random fuzzer runs to queue
+        description: Positive integer number of random fuzzer runs to queue
         required: false
         type: number
         default: 10
@@ -96,13 +96,27 @@ jobs:
           import json
           import os
 
-          run_count = int(float(os.environ["RUN_COUNT"]))
+          raw_run_count = os.environ["RUN_COUNT"]
+          parsed_run_count = float(raw_run_count)
+          if not parsed_run_count.is_integer():
+              raise SystemExit(
+                  f"inputs.run_count must be a positive integer, got {raw_run_count!r}"
+              )
+
+          run_count = int(parsed_run_count)
+          if run_count < 1:
+              raise SystemExit(
+                  f"inputs.run_count must be at least 1, got {raw_run_count!r}"
+              )
+
           runs = [{"run_id": run_id} for run_id in range(1, run_count + 1)]
           print(f"runs={json.dumps(runs)}")
           PY
 
   build-valkey:
     name: Build Valkey
+    needs:
+      - prepare-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -319,6 +333,7 @@ jobs:
     name: Summarize PR fuzzer results
     if: ${{ always() }}
     needs:
+      - prepare-matrix
       - build-valkey
       - random-fuzzer
     runs-on: ubuntu-latest
@@ -332,6 +347,7 @@ jobs:
 
       - name: Write workflow summary
         env:
+          PREPARE_MATRIX_RESULT: ${{ needs.prepare-matrix.result }}
           BUILD_RESULT: ${{ needs.build-valkey.result }}
           RESOLVED_SHA: ${{ needs.build-valkey.outputs.resolved_sha }}
           RUN_COUNT: ${{ inputs.run_count }}
@@ -347,7 +363,31 @@ jobs:
           import os
           import sys
 
-          run_count = int(float(os.environ["RUN_COUNT"]))
+          raw_run_count = os.environ["RUN_COUNT"]
+          run_count_error = None
+
+          try:
+              parsed_run_count = float(raw_run_count)
+          except ValueError:
+              run_count_error = (
+                  f"inputs.run_count must be a positive integer, got {raw_run_count!r}"
+              )
+              run_count = 0
+          else:
+              if not parsed_run_count.is_integer():
+                  run_count_error = (
+                      f"inputs.run_count must be a positive integer, got {raw_run_count!r}"
+                  )
+                  run_count = 0
+              else:
+                  run_count = int(parsed_run_count)
+                  if run_count < 1:
+                      run_count_error = (
+                          f"inputs.run_count must be at least 1, got {raw_run_count!r}"
+                      )
+                      run_count = 0
+
+          prepare_matrix_result = os.environ["PREPARE_MATRIX_RESULT"]
           build_result = os.environ["BUILD_RESULT"]
           summary_path = os.environ["GITHUB_STEP_SUMMARY"]
 
@@ -368,7 +408,13 @@ jobs:
 
           passed_runs = sum(1 for result in run_results.values() if result["status"] == "success")
           failed_runs = sum(1 for result in run_results.values() if result["status"] != "success")
-          overall_failed = build_result != "success" or failed_runs > 0 or bool(missing_runs)
+          overall_failed = (
+              prepare_matrix_result != "success"
+              or build_result != "success"
+              or failed_runs > 0
+              or bool(missing_runs)
+              or run_count_error is not None
+          )
 
           pr_line = ""
           if os.environ["PR_NUMBER"]:
@@ -384,36 +430,45 @@ jobs:
               f"- Requested ref: `{os.environ['VALKEY_REF']}`",
               f"- Resolved SHA: `{os.environ['RESOLVED_SHA'] or 'unavailable'}`",
               f"- Trigger label: `{os.environ['LABEL_NAME']}`",
+              f"- Matrix preparation: `{prepare_matrix_result}`",
           ]
 
           if pr_line:
               lines.append(pr_line.rstrip())
 
-          lines.extend([
-              f"- Passed runs: {passed_runs}/{run_count}",
-              f"- Failed runs: {failed_runs}",
-              f"- Missing run artifacts: {len(missing_runs)}",
-              "",
-              "| Run | Status | Seed | Stage | Duration (s) | Post-op Failures | Final Checks | Error |",
-              "| --- | --- | --- | --- | --- | --- | --- | --- |",
-          ])
+          if run_count_error is not None:
+              lines.extend([
+                  f"- Requested runs: `{raw_run_count}`",
+                  f"- Invalid `run_count`: {run_count_error}",
+              ])
+          else:
+              lines.extend([
+                  f"- Passed runs: {passed_runs}/{run_count}",
+                  f"- Failed runs: {failed_runs}",
+                  f"- Missing run artifacts: {len(missing_runs)}",
+                  "",
+                  "| Run | Status | Seed | Stage | Duration (s) | Post-op Failures | Final Checks | Error |",
+                  "| --- | --- | --- | --- | --- | --- | --- | --- |",
+              ])
 
-          for run_id in range(1, run_count + 1):
-              result = run_results.get(run_id)
-              if result is None:
-                  lines.append(f"| {run_id} | missing | - | artifact | - | artifact not uploaded |")
-                  continue
+              for run_id in range(1, run_count + 1):
+                  result = run_results.get(run_id)
+                  if result is None:
+                      lines.append(
+                          f"| {run_id} | missing | - | artifact | - | - | - | artifact not uploaded |"
+                      )
+                      continue
 
-              error = result.get("error_message") or "-"
-              error = str(error).replace("\n", " ").replace("|", "/")
-              seed = result.get("seed") if result.get("seed") is not None else "-"
-              duration = result.get("duration") if result.get("duration") is not None else "-"
-              post_op_failures = result.get("post_operation_validation_failures", 0)
-              final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
-              final_checks = final_checks.replace("|", "/")
-              lines.append(
-                  f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {duration} | {post_op_failures} | {final_checks} | {error} |"
-              )
+                  error = result.get("error_message") or "-"
+                  error = str(error).replace("\n", " ").replace("|", "/")
+                  seed = result.get("seed") if result.get("seed") is not None else "-"
+                  duration = result.get("duration") if result.get("duration") is not None else "-"
+                  post_op_failures = result.get("post_operation_validation_failures", 0)
+                  final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
+                  final_checks = final_checks.replace("|", "/")
+                  lines.append(
+                      f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {duration} | {post_op_failures} | {final_checks} | {error} |"
+                  )
 
           if missing_runs:
               lines.extend([

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -123,7 +123,7 @@ jobs:
       resolved_sha: ${{ steps.commit.outputs.sha }}
     steps:
       - name: Checkout Valkey
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ inputs.valkey_repository }}
           ref: ${{ inputs.valkey_ref }}
@@ -145,7 +145,7 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Upload Valkey binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: valkey-pr-binaries
           if-no-files-found: error
@@ -167,13 +167,13 @@ jobs:
         include: ${{ fromJson(needs.prepare-matrix.outputs.runs) }}
     steps:
       - name: Checkout valkey-fuzzer
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ github.event_name == 'workflow_call' && 'sarthakaggarwal97/valkey-fuzzer' || github.repository }}
           ref: ${{ github.event_name == 'workflow_call' && inputs.fuzzer_ref || github.sha }}
 
       - name: Download Valkey binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: valkey-pr-binaries
           path: ${{ runner.temp }}/valkey-binaries
@@ -182,7 +182,7 @@ jobs:
         run: chmod +x "${{ runner.temp }}/valkey-binaries/"*
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: valkey-pr-fuzzer-run-${{ matrix.run_id }}
           if-no-files-found: error
@@ -340,7 +340,7 @@ jobs:
     steps:
       - name: Download run artifacts
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: valkey-pr-fuzzer-run-*
           path: collected-results

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -1,4 +1,4 @@
-name: Valkey PR Fuzzer
+name: Valkey Cluster PR Fuzzer
 
 on:
   workflow_call:
@@ -36,7 +36,7 @@ on:
         description: Trigger label, used only for summaries
         required: false
         type: string
-        default: run-fuzzer
+        default: run-cluster-fuzzer
       run_count:
         description: Positive integer number of random fuzzer runs to queue
         required: false
@@ -77,7 +77,7 @@ on:
         description: Trigger label, used only for summaries
         required: false
         type: string
-        default: run-fuzzer
+        default: run-cluster-fuzzer
       run_count:
         description: Positive integer number of random fuzzer runs to queue
         required: false
@@ -86,6 +86,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: valkey-pr-fuzzer-${{ inputs.valkey_repository }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref }}
@@ -93,6 +94,8 @@ concurrency:
 
 jobs:
   prepare-matrix:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       fuzzer_repository: ${{ steps.resolve_fuzzer_source.outputs.repository }}
@@ -169,6 +172,8 @@ jobs:
     name: Build Valkey
     needs:
       - prepare-matrix
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -181,6 +186,7 @@ jobs:
           ref: ${{ inputs.valkey_ref }}
           fetch-depth: 1
           path: valkey-src
+          persist-credentials: false
 
       - name: Install build dependencies
         run: |
@@ -211,6 +217,8 @@ jobs:
     needs:
       - prepare-matrix
       - build-valkey
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -223,6 +231,7 @@ jobs:
         with:
           repository: ${{ needs.prepare-matrix.outputs.fuzzer_repository }}
           ref: ${{ needs.prepare-matrix.outputs.fuzzer_ref }}
+          persist-credentials: false
 
       - name: Download Valkey binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -382,12 +391,15 @@ jobs:
         run: exit 1
 
   summarize:
-    name: Summarize PR fuzzer results
+    name: Summarize cluster fuzzer results
     if: ${{ always() }}
     needs:
       - prepare-matrix
       - build-valkey
       - random-fuzzer
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Download run artifacts
@@ -398,6 +410,7 @@ jobs:
           path: collected-results
 
       - name: Write workflow summary
+        id: summary
         env:
           PREPARE_MATRIX_RESULT: ${{ needs.prepare-matrix.result }}
           BUILD_RESULT: ${{ needs.build-valkey.result }}
@@ -410,12 +423,12 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_URL: ${{ inputs.pr_url }}
           LABEL_NAME: ${{ inputs.label_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python - <<'PY'
           import glob
           import json
           import os
-          import sys
 
           raw_run_count = os.environ["RUN_COUNT"]
           run_count_error = None
@@ -444,6 +457,8 @@ jobs:
           prepare_matrix_result = os.environ["PREPARE_MATRIX_RESULT"]
           build_result = os.environ["BUILD_RESULT"]
           summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+          output_path = os.environ["GITHUB_OUTPUT"]
+          comment_path = "pr-comment.md"
 
           metadata_paths = sorted(
               glob.glob("collected-results/**/metadata.json", recursive=True)
@@ -477,8 +492,10 @@ jobs:
               else:
                   pr_line = f"- PR: #{os.environ['PR_NUMBER']}\n"
 
+          overall_status = "FAIL" if overall_failed else "PASS"
+
           lines = [
-              "## Valkey PR Fuzzer",
+              "## Valkey Cluster Fuzzer",
               "",
               f"- Valkey repository: `{os.environ['VALKEY_REPOSITORY']}`",
               f"- Requested ref: `{os.environ['VALKEY_REF']}`",
@@ -486,7 +503,9 @@ jobs:
               f"- Fuzzer repository: `{os.environ['FUZZER_REPOSITORY'] or 'unavailable'}`",
               f"- Fuzzer ref: `{os.environ['FUZZER_REF'] or 'unavailable'}`",
               f"- Trigger label: `{os.environ['LABEL_NAME']}`",
+              f"- Overall result: `{overall_status}`",
               f"- Matrix preparation: `{prepare_matrix_result}`",
+              f"- Build stage: `{build_result}`",
           ]
 
           if pr_line:
@@ -535,6 +554,116 @@ jobs:
           with open(summary_path, "a", encoding="utf-8") as handle:
               handle.write("\n".join(lines) + "\n")
 
-          if overall_failed:
-              sys.exit(1)
+          if os.environ["PR_NUMBER"]:
+              comment_lines = [
+                  "<!-- valkey-cluster-fuzzer-results -->",
+                  "## Valkey Cluster Fuzzer Results",
+                  "",
+                  f"- Overall result: `{overall_status}`",
+                  f"- Workflow run: [View run]({os.environ['RUN_URL']})",
+                  f"- Trigger label: `{os.environ['LABEL_NAME']}`",
+                  f"- Requested ref: `{os.environ['VALKEY_REF']}`",
+                  f"- Resolved SHA: `{os.environ['RESOLVED_SHA'] or 'unavailable'}`",
+                  f"- Fuzzer repository: `{os.environ['FUZZER_REPOSITORY'] or 'unavailable'}`",
+                  f"- Fuzzer ref: `{os.environ['FUZZER_REF'] or 'unavailable'}`",
+                  f"- Matrix preparation: `{prepare_matrix_result}`",
+                  f"- Build stage: `{build_result}`",
+              ]
+
+              if run_count_error is not None:
+                  comment_lines.extend([
+                      f"- Requested runs: `{raw_run_count}`",
+                      f"- Invalid `run_count`: {run_count_error}",
+                  ])
+              else:
+                  comment_lines.extend([
+                      f"- Passed runs: {passed_runs}/{run_count}",
+                      f"- Failed runs: {failed_runs}",
+                      f"- Missing run artifacts: {len(missing_runs)}",
+                      "",
+                      "<details>",
+                      "<summary>Per-run results</summary>",
+                      "",
+                      "| Run | Status | Seed | Stage | Duration (s) | Post-op Failures | Final Checks | Error |",
+                      "| --- | --- | --- | --- | --- | --- | --- | --- |",
+                  ])
+
+                  for run_id in range(1, run_count + 1):
+                      result = run_results.get(run_id)
+                      if result is None:
+                          comment_lines.append(
+                              f"| {run_id} | missing | - | artifact | - | - | - | artifact not uploaded |"
+                          )
+                          continue
+
+                      error = result.get("error_message") or "-"
+                      error = str(error).replace("\n", " ").replace("|", "/")
+                      seed = result.get("seed") if result.get("seed") is not None else "-"
+                      duration = result.get("duration") if result.get("duration") is not None else "-"
+                      post_op_failures = result.get("post_operation_validation_failures", 0)
+                      final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
+                      final_checks = final_checks.replace("|", "/")
+                      comment_lines.append(
+                          f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {duration} | {post_op_failures} | {final_checks} | {error} |"
+                      )
+
+                  comment_lines.extend([
+                      "",
+                      "</details>",
+                  ])
+
+              if missing_runs:
+                  comment_lines.extend([
+                      "",
+                      f"Missing artifacts for runs: {', '.join(str(run_id) for run_id in missing_runs)}",
+                  ])
+
+              with open(comment_path, "w", encoding="utf-8") as handle:
+                  handle.write("\n".join(comment_lines) + "\n")
+
+          with open(output_path, "a", encoding="utf-8") as handle:
+              handle.write(f"overall_failed={'true' if overall_failed else 'false'}\n")
           PY
+
+      - name: Comment on PR with fuzzer results
+        if: ${{ inputs.pr_number != '' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pr-comment.md', 'utf8');
+            const marker = '<!-- valkey-cluster-fuzzer-results -->';
+            const issue_number = Number('${{ inputs.pr_number }}');
+            const {owner, repo} = context.repo;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Mark summary job as failed when any run fails
+        if: steps.summary.outputs.overall_failed == 'true'
+        run: exit 1

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -86,6 +86,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -399,6 +400,7 @@ jobs:
       - random-fuzzer
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
@@ -555,19 +557,17 @@ jobs:
               handle.write("\n".join(lines) + "\n")
 
           if os.environ["PR_NUMBER"]:
+              def format_comment_value(value, limit=120):
+                  text = str(value).replace("\n", " ").replace("|", "/")
+                  return text if len(text) <= limit else text[: limit - 3] + "..."
+
               comment_lines = [
                   "<!-- valkey-cluster-fuzzer-results -->",
                   "## Valkey Cluster Fuzzer Results",
                   "",
                   f"- Overall result: `{overall_status}`",
                   f"- Workflow run: [View run]({os.environ['RUN_URL']})",
-                  f"- Trigger label: `{os.environ['LABEL_NAME']}`",
-                  f"- Requested ref: `{os.environ['VALKEY_REF']}`",
                   f"- Resolved SHA: `{os.environ['RESOLVED_SHA'] or 'unavailable'}`",
-                  f"- Fuzzer repository: `{os.environ['FUZZER_REPOSITORY'] or 'unavailable'}`",
-                  f"- Fuzzer ref: `{os.environ['FUZZER_REF'] or 'unavailable'}`",
-                  f"- Matrix preparation: `{prepare_matrix_result}`",
-                  f"- Build stage: `{build_result}`",
               ]
 
               if run_count_error is not None:
@@ -580,37 +580,41 @@ jobs:
                       f"- Passed runs: {passed_runs}/{run_count}",
                       f"- Failed runs: {failed_runs}",
                       f"- Missing run artifacts: {len(missing_runs)}",
-                      "",
-                      "<details>",
-                      "<summary>Per-run results</summary>",
-                      "",
-                      "| Run | Status | Seed | Stage | Duration (s) | Post-op Failures | Final Checks | Error |",
-                      "| --- | --- | --- | --- | --- | --- | --- | --- |",
                   ])
 
-                  for run_id in range(1, run_count + 1):
-                      result = run_results.get(run_id)
-                      if result is None:
+                  if overall_failed:
+                      comment_lines.extend([
+                          "",
+                          "<details>",
+                          "<summary>Failure details</summary>",
+                          "",
+                          "| Run | Status | Seed | Stage | Final Checks | Error |",
+                          "| --- | --- | --- | --- | --- | --- |",
+                      ])
+
+                      for run_id in range(1, run_count + 1):
+                          result = run_results.get(run_id)
+                          if result is None:
+                              comment_lines.append(
+                                  f"| {run_id} | missing | - | artifact | - | artifact not uploaded |"
+                              )
+                              continue
+
+                          if result["status"] == "success":
+                              continue
+
+                          error = format_comment_value(result.get("error_message") or "-")
+                          seed = result.get("seed") if result.get("seed") is not None else "-"
+                          final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
+                          final_checks = format_comment_value(final_checks, limit=80)
                           comment_lines.append(
-                              f"| {run_id} | missing | - | artifact | - | - | - | artifact not uploaded |"
+                              f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {final_checks} | {error} |"
                           )
-                          continue
 
-                      error = result.get("error_message") or "-"
-                      error = str(error).replace("\n", " ").replace("|", "/")
-                      seed = result.get("seed") if result.get("seed") is not None else "-"
-                      duration = result.get("duration") if result.get("duration") is not None else "-"
-                      post_op_failures = result.get("post_operation_validation_failures", 0)
-                      final_checks = ", ".join(result.get("final_failed_checks", [])) or "-"
-                      final_checks = final_checks.replace("|", "/")
-                      comment_lines.append(
-                          f"| {run_id} | {result['status']} | {seed} | {result.get('stage', '-')} | {duration} | {post_op_failures} | {final_checks} | {error} |"
-                      )
-
-                  comment_lines.extend([
-                      "",
-                      "</details>",
-                  ])
+                      comment_lines.extend([
+                          "",
+                          "</details>",
+                      ])
 
               if missing_runs:
                   comment_lines.extend([

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -114,12 +114,33 @@ jobs:
         run: |
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import os
+          import subprocess
 
           event_name = os.environ["EVENT_NAME"]
           input_repository = os.environ["INPUT_FUZZER_REPOSITORY"].strip()
           input_ref = os.environ["INPUT_FUZZER_REF"].strip()
           default_repository = os.environ["DEFAULT_FUZZER_REPOSITORY"]
           default_ref = os.environ["DEFAULT_FUZZER_REF"]
+
+          def resolve_default_branch(repository):
+              remote = f"https://github.com/{repository}.git"
+              try:
+                  output = subprocess.check_output(
+                      ["git", "ls-remote", "--symref", remote, "HEAD"],
+                      text=True,
+                      stderr=subprocess.STDOUT,
+                  )
+              except subprocess.CalledProcessError as exc:
+                  error_output = exc.output.strip() or str(exc)
+                  raise SystemExit(
+                      f"Could not determine the default branch for {repository!r}: {error_output}"
+                  ) from exc
+              for line in output.splitlines():
+                  if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
+                      return line[len("ref: refs/heads/"):-len("\tHEAD")]
+              raise SystemExit(
+                  f"Could not determine the default branch for {repository!r} from {remote}"
+              )
 
           if event_name == "workflow_call":
               missing_inputs = []
@@ -137,7 +158,12 @@ jobs:
               resolved_ref = input_ref
           else:
               resolved_repository = input_repository or default_repository
-              resolved_ref = input_ref or default_ref
+              if input_ref:
+                  resolved_ref = input_ref
+              elif input_repository and input_repository != default_repository:
+                  resolved_ref = resolve_default_branch(resolved_repository)
+              else:
+                  resolved_ref = default_ref
 
           print(f"repository={resolved_repository}")
           print(f"ref={resolved_ref}")

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -1,4 +1,4 @@
-name: PR Merge Valkey Fuzzer
+name: Valkey PR Fuzzer
 
 on:
   workflow_call:
@@ -78,7 +78,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-merge-fuzzer-${{ inputs.valkey_repository }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref }}
+  group: valkey-pr-fuzzer-${{ inputs.valkey_repository }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref }}
   cancel-in-progress: false
 
 jobs:
@@ -191,7 +191,7 @@ jobs:
         continue-on-error: true
         env:
           RUN_ID: ${{ matrix.run_id }}
-          RUN_ROOT: ${{ runner.temp }}/pr-merge-fuzzer
+          RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
           VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
         run: |
           set +e
@@ -323,7 +323,7 @@ jobs:
         with:
           name: valkey-pr-fuzzer-run-${{ matrix.run_id }}
           if-no-files-found: error
-          path: ${{ runner.temp }}/pr-merge-fuzzer/run-${{ matrix.run_id }}
+          path: ${{ runner.temp }}/valkey-pr-fuzzer/run-${{ matrix.run_id }}
 
       - name: Mark job as failed when the fuzzer run fails
         if: steps.execute.outputs.exit_code != '0'
@@ -424,7 +424,7 @@ jobs:
                   pr_line = f"- PR: #{os.environ['PR_NUMBER']}\n"
 
           lines = [
-              "## PR Merge Valkey Fuzzer",
+              "## Valkey PR Fuzzer",
               "",
               f"- Valkey repository: `{os.environ['VALKEY_REPOSITORY']}`",
               f"- Requested ref: `{os.environ['VALKEY_REF']}`",

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -3,11 +3,16 @@ name: Valkey PR Fuzzer
 on:
   workflow_call:
     inputs:
-      fuzzer_ref:
-        description: Ref of this repo to check out when called from another repo
+      fuzzer_repository:
+        description: Repository containing the fuzzer workflow and code to check out when called from another repo
         required: false
         type: string
-        default: main
+        default: ""
+      fuzzer_ref:
+        description: Full commit SHA of the fuzzer repo to check out when called from another repo
+        required: false
+        type: string
+        default: ""
       valkey_repository:
         description: Repository containing the Valkey PR to test
         required: false
@@ -39,11 +44,16 @@ on:
         default: 10
   workflow_dispatch:
     inputs:
-      fuzzer_ref:
-        description: Ref of this repo to check out
+      fuzzer_repository:
+        description: Repository containing the fuzzer workflow and code to check out
         required: false
         type: string
-        default: main
+        default: ""
+      fuzzer_ref:
+        description: Ref of the fuzzer repo to check out
+        required: false
+        type: string
+        default: ""
       valkey_repository:
         description: Repository containing the Valkey commit to test
         required: false
@@ -85,8 +95,55 @@ jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
     outputs:
+      fuzzer_repository: ${{ steps.resolve_fuzzer_source.outputs.repository }}
+      fuzzer_ref: ${{ steps.resolve_fuzzer_source.outputs.ref }}
       runs: ${{ steps.matrix.outputs.runs }}
     steps:
+      - name: Resolve fuzzer source
+        id: resolve_fuzzer_source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_FUZZER_REPOSITORY: ${{ inputs.fuzzer_repository }}
+          INPUT_FUZZER_REF: ${{ inputs.fuzzer_ref }}
+          DEFAULT_FUZZER_REPOSITORY: ${{ github.repository }}
+          DEFAULT_FUZZER_REF: ${{ github.sha }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          import re
+
+          event_name = os.environ["EVENT_NAME"]
+          input_repository = os.environ["INPUT_FUZZER_REPOSITORY"].strip()
+          input_ref = os.environ["INPUT_FUZZER_REF"].strip()
+          default_repository = os.environ["DEFAULT_FUZZER_REPOSITORY"]
+          default_ref = os.environ["DEFAULT_FUZZER_REF"]
+
+          if event_name == "workflow_call":
+              missing_inputs = []
+              if not input_repository:
+                  missing_inputs.append("fuzzer_repository")
+              if not input_ref:
+                  missing_inputs.append("fuzzer_ref")
+              if missing_inputs:
+                  missing_list = ", ".join(f"inputs.{name}" for name in missing_inputs)
+                  raise SystemExit(
+                      "workflow_call requires "
+                      f"{missing_list} so the reusable workflow checks out the exact fuzzer repo and commit it was reviewed with"
+                  )
+              if not re.fullmatch(r"[0-9a-fA-F]{40}", input_ref):
+                  raise SystemExit(
+                      "workflow_call requires inputs.fuzzer_ref to be a full 40-character commit SHA"
+                  )
+              resolved_repository = input_repository
+              resolved_ref = input_ref
+          else:
+              resolved_repository = input_repository or default_repository
+              resolved_ref = input_ref or default_ref
+
+          print(f"repository={resolved_repository}")
+          print(f"ref={resolved_ref}")
+          PY
+
       - name: Build matrix
         id: matrix
         env:
@@ -169,8 +226,8 @@ jobs:
       - name: Checkout valkey-fuzzer
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          repository: ${{ github.event_name == 'workflow_call' && 'sarthakaggarwal97/valkey-fuzzer' || github.repository }}
-          ref: ${{ github.event_name == 'workflow_call' && inputs.fuzzer_ref || github.sha }}
+          repository: ${{ needs.prepare-matrix.outputs.fuzzer_repository }}
+          ref: ${{ needs.prepare-matrix.outputs.fuzzer_ref }}
 
       - name: Download Valkey binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -350,6 +407,8 @@ jobs:
           PREPARE_MATRIX_RESULT: ${{ needs.prepare-matrix.result }}
           BUILD_RESULT: ${{ needs.build-valkey.result }}
           RESOLVED_SHA: ${{ needs.build-valkey.outputs.resolved_sha }}
+          FUZZER_REPOSITORY: ${{ needs.prepare-matrix.outputs.fuzzer_repository }}
+          FUZZER_REF: ${{ needs.prepare-matrix.outputs.fuzzer_ref }}
           RUN_COUNT: ${{ inputs.run_count }}
           VALKEY_REPOSITORY: ${{ inputs.valkey_repository }}
           VALKEY_REF: ${{ inputs.valkey_ref }}
@@ -429,6 +488,8 @@ jobs:
               f"- Valkey repository: `{os.environ['VALKEY_REPOSITORY']}`",
               f"- Requested ref: `{os.environ['VALKEY_REF']}`",
               f"- Resolved SHA: `{os.environ['RESOLVED_SHA'] or 'unavailable'}`",
+              f"- Fuzzer repository: `{os.environ['FUZZER_REPOSITORY'] or 'unavailable'}`",
+              f"- Fuzzer ref: `{os.environ['FUZZER_REF'] or 'unavailable'}`",
               f"- Trigger label: `{os.environ['LABEL_NAME']}`",
               f"- Matrix preparation: `{prepare_matrix_result}`",
           ]

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: ""
       fuzzer_ref:
-        description: Full commit SHA of the fuzzer repo to check out when called from another repo
+        description: Branch, tag, or commit SHA of the fuzzer repo to check out when called from another repo
         required: false
         type: string
         default: ""
@@ -50,7 +50,7 @@ on:
         type: string
         default: ""
       fuzzer_ref:
-        description: Ref of the fuzzer repo to check out
+        description: Branch, tag, or commit SHA of the fuzzer repo to check out
         required: false
         type: string
         default: ""
@@ -110,7 +110,6 @@ jobs:
         run: |
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import os
-          import re
 
           event_name = os.environ["EVENT_NAME"]
           input_repository = os.environ["INPUT_FUZZER_REPOSITORY"].strip()
@@ -128,11 +127,7 @@ jobs:
                   missing_list = ", ".join(f"inputs.{name}" for name in missing_inputs)
                   raise SystemExit(
                       "workflow_call requires "
-                      f"{missing_list} so the reusable workflow checks out the exact fuzzer repo and commit it was reviewed with"
-                  )
-              if not re.fullmatch(r"[0-9a-fA-F]{40}", input_ref):
-                  raise SystemExit(
-                      "workflow_call requires inputs.fuzzer_ref to be a full 40-character commit SHA"
+                      f"{missing_list} so the reusable workflow checks out the intended fuzzer repo and ref"
                   )
               resolved_repository = input_repository
               resolved_ref = input_ref

--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ __marimo__/
 
 .*/
 !.github/
+!.github/dependabot.yml
 !.github/workflows/
 !.github/workflows/*.yml
 !.github/workflows/*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,7 @@ marimo/_lsp/
 __marimo__/
 
 .*/
+!.github/
+!.github/workflows/
+!.github/workflows/*.yml
+!.github/workflows/*.yaml

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ valkey-fuzzer cluster --dsl examples/simple_failover.yaml --valkey-binary /tmp/v
 
 ### PR-Triggered Fuzzer Runs
 
-This repo now includes a reusable GitHub Actions workflow at `.github/workflows/pr-merge-fuzzer.yml` that can:
+This repo now includes a reusable GitHub Actions workflow at `.github/workflows/valkey-pr-fuzzer.yml` that can:
 
 - build Valkey from a specific ref, including a PR merge ref such as `refs/pull/123/merge`
 - fan out a configurable number of random fuzzer runs, defaulting to `10`
@@ -121,7 +121,7 @@ permissions:
 jobs:
   pr-fuzzer:
     if: github.event.label.name == 'run-fuzzer'
-    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/pr-merge-fuzzer.yml@main
+    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@main
     with:
       fuzzer_ref: main
       valkey_repository: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -88,7 +88,51 @@ valkey-fuzzer cluster --random --verbose
 # Run with iterations 
 valkey-fuzzer cluster --seed 42 --iterations 2 --verbose
 
+# Run against a specific Valkey binary
+valkey-fuzzer cluster --random --valkey-binary /tmp/valkey/src/valkey-server
+
+# Run a DSL scenario against a specific Valkey binary
+valkey-fuzzer cluster --dsl examples/simple_failover.yaml --valkey-binary /tmp/valkey/src/valkey-server
+
 ```
+
+### PR-Triggered Fuzzer Runs
+
+This repo now includes a reusable GitHub Actions workflow at `.github/workflows/pr-merge-fuzzer.yml` that can:
+
+- build Valkey from a specific ref, including a PR merge ref such as `refs/pull/123/merge`
+- fan out a configurable number of random fuzzer runs, defaulting to `10`
+- upload per-run artifacts with the console log, node logs, and JSON result payload
+- fail the overall workflow if any run fails, while still letting all matrix runs complete
+- treat a run as failed if any operation fails, any chaos injection fails, any post-operation validation wave fails, or the final validation fails
+
+If you want this to run when a label is applied in the Valkey repo, the Valkey repo needs a small caller workflow. Example:
+
+```yaml
+name: Label-triggered Valkey Fuzzer
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-fuzzer:
+    if: github.event.label.name == 'run-fuzzer'
+    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/pr-merge-fuzzer.yml@main
+    with:
+      fuzzer_ref: main
+      valkey_repository: ${{ github.repository }}
+      valkey_ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      label_name: ${{ github.event.label.name }}
+      run_count: 10
+```
+
+This keeps the status visible on the Valkey PR as a normal workflow check. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
 
 ### DSL-Based Test Execution
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ permissions:
 jobs:
   pr-fuzzer:
     if: github.event.label.name == 'run-fuzzer'
-    uses: valkey-io/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@<full-commit-sha>
+    uses: valkey-io/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@main
     with:
       fuzzer_repository: valkey-io/valkey-fuzzer
-      fuzzer_ref: <same-full-commit-sha>
+      fuzzer_ref: main
       valkey_repository: ${{ github.repository }}
       valkey_ref: refs/pull/${{ github.event.pull_request.number }}/merge
       pr_number: ${{ github.event.pull_request.number }}
@@ -133,7 +133,7 @@ jobs:
       run_count: 10
 ```
 
-Pin the reusable workflow and pass the same full commit SHA in `fuzzer_ref`, along with the matching `fuzzer_repository`, so the caller executes the exact immutable version of the fuzzer workflow and code that was reviewed.
+For the simplest setup, point both the reusable workflow ref and `fuzzer_ref` at `main`, along with the matching `fuzzer_repository`, so the caller executes the current upstream workflow and fuzzer code. If you want tighter reproducibility, switch both references to the same tag or commit SHA instead.
 
 This keeps the status visible on the Valkey PR as a normal workflow check. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ jobs:
   pr-fuzzer:
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     if: github.event.label.name == 'run-cluster-fuzzer'
     uses: valkey-io/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@main
@@ -139,6 +140,8 @@ jobs:
 For the simplest setup, point both the reusable workflow ref and `fuzzer_ref` at `main`, along with the matching `fuzzer_repository`, so the caller executes the current upstream workflow and fuzzer code. If you want tighter reproducibility, switch both references to the same tag or commit SHA instead.
 
 This keeps the status visible on the Valkey PR as a normal workflow check, and the reusable workflow updates a sticky PR comment with the latest run summary. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
+
+You can also add a small cleanup job in the caller workflow to remove `run-cluster-fuzzer` after the run finishes, so maintainers can rerun by simply reapplying the label.
 
 ### DSL-Based Test Execution
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ permissions:
 jobs:
   pr-fuzzer:
     if: github.event.label.name == 'run-fuzzer'
-    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@<full-commit-sha>
+    uses: valkey-io/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@<full-commit-sha>
     with:
-      fuzzer_ref: <full-commit-sha>
+      fuzzer_repository: valkey-io/valkey-fuzzer
+      fuzzer_ref: <same-full-commit-sha>
       valkey_repository: ${{ github.repository }}
       valkey_ref: refs/pull/${{ github.event.pull_request.number }}/merge
       pr_number: ${{ github.event.pull_request.number }}
@@ -132,7 +133,7 @@ jobs:
       run_count: 10
 ```
 
-Pin the reusable workflow and `fuzzer_ref` to the same full commit SHA so the caller executes an immutable version of the fuzzer workflow and code.
+Pin the reusable workflow and pass the same full commit SHA in `fuzzer_ref`, along with the matching `fuzzer_repository`, so the caller executes the exact immutable version of the fuzzer workflow and code that was reviewed.
 
 This keeps the status visible on the Valkey PR as a normal workflow check. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This repo now includes a reusable GitHub Actions workflow at `.github/workflows/
 If you want this to run when a label is applied in the Valkey repo, the Valkey repo needs a small caller workflow. Example:
 
 ```yaml
-name: Label-triggered Valkey Fuzzer
+name: Label-triggered Valkey Cluster Fuzzer
 
 on:
   pull_request_target:
@@ -120,7 +120,10 @@ permissions:
 
 jobs:
   pr-fuzzer:
-    if: github.event.label.name == 'run-fuzzer'
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.event.label.name == 'run-cluster-fuzzer'
     uses: valkey-io/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@main
     with:
       fuzzer_repository: valkey-io/valkey-fuzzer
@@ -135,7 +138,7 @@ jobs:
 
 For the simplest setup, point both the reusable workflow ref and `fuzzer_ref` at `main`, along with the matching `fuzzer_repository`, so the caller executes the current upstream workflow and fuzzer code. If you want tighter reproducibility, switch both references to the same tag or commit SHA instead.
 
-This keeps the status visible on the Valkey PR as a normal workflow check. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
+This keeps the status visible on the Valkey PR as a normal workflow check, and the reusable workflow updates a sticky PR comment with the latest run summary. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
 
 ### DSL-Based Test Execution
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ permissions:
 jobs:
   pr-fuzzer:
     if: github.event.label.name == 'run-fuzzer'
-    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@main
+    uses: sarthakaggarwal97/valkey-fuzzer/.github/workflows/valkey-pr-fuzzer.yml@<full-commit-sha>
     with:
-      fuzzer_ref: main
+      fuzzer_ref: <full-commit-sha>
       valkey_repository: ${{ github.repository }}
       valkey_ref: refs/pull/${{ github.event.pull_request.number }}/merge
       pr_number: ${{ github.event.pull_request.number }}
@@ -131,6 +131,8 @@ jobs:
       label_name: ${{ github.event.label.name }}
       run_count: 10
 ```
+
+Pin the reusable workflow and `fuzzer_ref` to the same full commit SHA so the caller executes an immutable version of the fuzzer workflow and code.
 
 This keeps the status visible on the Valkey PR as a normal workflow check. If the PR cannot produce a merge ref, for example due to merge conflicts, the workflow will fail during the Valkey checkout/build stage.
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -79,7 +79,11 @@ class FuzzerCLI:
                 print(f"\n--- Iteration {i + 1}/{args.iterations} ---")
             
             try:
-                result = self.fuzzer.run_random_test(seed=seed)
+                run_kwargs = {'seed': seed}
+                if args.valkey_binary:
+                    run_kwargs['valkey_binary'] = args.valkey_binary
+
+                result = self.fuzzer.run_random_test(**run_kwargs)
                 results.append(result)
                 
                 if args.verbose:
@@ -134,7 +138,11 @@ class FuzzerCLI:
             print()
             
             # Run test
-            result = self.fuzzer.run_dsl_test(dsl_config)
+            run_kwargs = {}
+            if args.valkey_binary:
+                run_kwargs['valkey_binary'] = args.valkey_binary
+
+            result = self.fuzzer.run_dsl_test(dsl_config, **run_kwargs)
             
             if args.verbose:
                 self._print_detailed_result(result)
@@ -550,6 +558,11 @@ Examples:
         '--config',
         type=str,
         help='Path to configuration file (YAML or JSON)'
+    )
+    cluster_parser.add_argument(
+        '--valkey-binary',
+        type=str,
+        help='Path to the valkey-server binary to run'
     )
     cluster_parser.add_argument(
         '--output',

--- a/src/cli.py
+++ b/src/cli.py
@@ -659,6 +659,7 @@ def main():
             if args.dsl:
                 dsl_args = type('obj', (object,), {
                     'file': args.dsl,
+                    'valkey_binary': args.valkey_binary,
                     'output': args.output,
                     'format': args.format,
                     'verbose': args.verbose

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -56,12 +56,23 @@ class ConfigurationManager:
         """Clone and build Valkey binary, return path to valkey-server binary"""
         configured_binary = self.clusterConfig.valkey_binary
         if configured_binary:
+            # For absolute/relative paths, check existence and permissions directly
+            if os.path.sep in configured_binary or configured_binary.startswith('.'):
+                if not os.path.isfile(configured_binary):
+                    raise FileNotFoundError(
+                        f"Configured valkey_binary '{configured_binary}' does not exist."
+                    )
+                if not os.access(configured_binary, os.X_OK):
+                    raise PermissionError(
+                        f"Configured valkey_binary '{configured_binary}' exists but is not executable."
+                    )
+                return os.path.abspath(configured_binary)
+            # Bare command name — search PATH
             resolved_binary = shutil.which(configured_binary)
             if resolved_binary:
                 return resolved_binary
             raise FileNotFoundError(
-                f"Configured valkey_binary '{configured_binary}' could not be resolved. "
-                "Check the path or ensure the binary is on PATH."
+                f"Configured valkey_binary '{configured_binary}' could not be found on PATH."
             )
 
         valkey_binary = shutil.which('valkey-server')

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -67,7 +67,12 @@ class ConfigurationManager:
                         f"Configured valkey_binary '{configured_binary}' exists but is not executable."
                     )
                 return os.path.abspath(configured_binary)
-            # Bare command name — search PATH
+            resolved_binary = shutil.which(configured_binary)
+            if resolved_binary:
+                return resolved_binary
+            raise FileNotFoundError(
+                f"Configured valkey_binary '{configured_binary}' could not be found on PATH."
+            )
             resolved_binary = shutil.which(configured_binary)
             if resolved_binary:
                 return resolved_binary

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -54,9 +54,14 @@ class ConfigurationManager:
     
     def setup_valkey_from_source(self, base_dir: str = "/tmp/valkey-build") -> str:
         """Clone and build Valkey binary, return path to valkey-server binary"""
-        result = subprocess.run(['which', 'valkey-server'], capture_output=True, text=True)
-        if result.returncode == 0:
-            valkey_binary = result.stdout.strip()
+        configured_binary = self.clusterConfig.valkey_binary
+        if configured_binary:
+            resolved_binary = shutil.which(configured_binary)
+            if resolved_binary:
+                return resolved_binary
+
+        valkey_binary = shutil.which('valkey-server')
+        if valkey_binary:
             return valkey_binary
                 
         valkey_dir = os.path.join(base_dir, "valkey")

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -67,12 +67,7 @@ class ConfigurationManager:
                         f"Configured valkey_binary '{configured_binary}' exists but is not executable."
                     )
                 return os.path.abspath(configured_binary)
-            resolved_binary = shutil.which(configured_binary)
-            if resolved_binary:
-                return resolved_binary
-            raise FileNotFoundError(
-                f"Configured valkey_binary '{configured_binary}' could not be found on PATH."
-            )
+            # Bare command name — search PATH
             resolved_binary = shutil.which(configured_binary)
             if resolved_binary:
                 return resolved_binary

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -59,6 +59,10 @@ class ConfigurationManager:
             resolved_binary = shutil.which(configured_binary)
             if resolved_binary:
                 return resolved_binary
+            raise FileNotFoundError(
+                f"Configured valkey_binary '{configured_binary}' could not be resolved. "
+                "Check the path or ensure the binary is on PATH."
+            )
 
         valkey_binary = shutil.which('valkey-server')
         if valkey_binary:

--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -80,7 +80,18 @@ class ChaosCoordinator:
             target_node = self.chaos_engine.target_selector.select_target(cluster_id, chaos_config.target_selection, log_buffer=log)
             
             if not target_node:
-                log.warning("No suitable chaos target found")
+                error_message = (
+                    f"No suitable chaos target found for operation "
+                    f"{operation.type.value} on {operation.target_node}"
+                )
+                log.error(error_message)
+                failure_result = self._build_failed_chaos_result(
+                    chaos_config,
+                    operation.target_node,
+                    error_message
+                )
+                chaos_results.append(failure_result)
+                self.chaos_history.append(failure_result)
                 return chaos_results
             
             # Execute chaos based on coordination configuration
@@ -134,9 +145,39 @@ class ChaosCoordinator:
             self.chaos_history.extend(actual_results)
             
         except Exception as e:
-            logger.error(f"Failed to coordinate chaos with operation: {e}")
+            error_message = (
+                f"Failed to coordinate chaos with operation "
+                f"{operation.type.value} on {operation.target_node}: {e}"
+            )
+            log.error(error_message)
+            failure_result = self._build_failed_chaos_result(
+                chaos_config,
+                operation.target_node,
+                error_message
+            )
+            chaos_results.append(failure_result)
+            actual_results = [r for r in chaos_results if isinstance(r, ChaosResult)]
+            self.chaos_history.extend(actual_results)
         
         return chaos_results
+
+    def _build_failed_chaos_result(
+        self,
+        chaos_config: ChaosConfig,
+        target_node: str,
+        error_message: str
+    ) -> ChaosResult:
+        """Create a failed chaos result for coordination or target-selection failures."""
+        failure_time = time.time()
+        return ChaosResult(
+            chaos_id="coordination-failure",
+            chaos_type=chaos_config.chaos_type,
+            target_node=target_node,
+            success=False,
+            start_time=failure_time,
+            end_time=failure_time,
+            error_message=error_message
+        )
     
     def _convert_dict_nodes_to_nodeinfo(self, live_nodes_dict: List[dict], initial_nodes: List[NodeInfo]) -> List[NodeInfo]:
         """Convert dictionary node representations to NodeInfo objects with live roles."""

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -420,7 +420,7 @@ class FuzzerEngine(IFuzzerEngine):
                     f"{len(failed_validation_waves)} post-operation validation wave(s) failed"
                 )
         elif total_operations > 0 and operations_executed == total_operations:
-            failure_reasons.append("post-operation validation did not run")
+        if not final_validation_result.overall_success:
 
         if not final_validation_result.overall_success:
             failed_checks = ", ".join(final_validation_result.failed_checks) or "unknown checks"

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -410,9 +410,7 @@ class FuzzerEngine(IFuzzerEngine):
         if failed_chaos_events:
             failure_reasons.append(f"{len(failed_chaos_events)} chaos injection(s) failed")
 
-        if total_operations > 0 and not validation_results:
-            failure_reasons.append("post-operation validation did not run")
-        else:
+        if validation_results:
             failed_validation_waves = [
                 result for result in validation_results
                 if not result.overall_success

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -419,6 +419,8 @@ class FuzzerEngine(IFuzzerEngine):
                 failure_reasons.append(
                     f"{len(failed_validation_waves)} post-operation validation wave(s) failed"
                 )
+        elif total_operations > 0 and operations_executed == total_operations:
+            failure_reasons.append("post-operation validation did not run")
 
         if not final_validation_result.overall_success:
             failed_checks = ", ".join(final_validation_result.failed_checks) or "unknown checks"

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -4,8 +4,7 @@ Fuzzer Engine - Main orchestrator for test scenario execution
 import time
 import logging
 from copy import deepcopy
-from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 from ..models import Scenario, ExecutionResult, DSLConfig, ClusterConnection, LogValidationContext
 from ..interfaces import IFuzzerEngine
 from ..valkey_client.load_data import load_all_slots
@@ -41,13 +40,16 @@ class FuzzerEngine(IFuzzerEngine):
         logger.info(f"Generating random scenario with seed: {seed}")
         return self.scenario_generator.generate_random_scenario(seed)
     
-    def execute_dsl_scenario(self, dsl_config: DSLConfig) -> ExecutionResult:
+    def execute_dsl_scenario(self, dsl_config: DSLConfig, valkey_binary: Optional[str] = None) -> ExecutionResult:
         """Execute a test scenario from DSL configuration."""
         logger.info("Executing DSL-based scenario")
         
         try:
             # Parse DSL configuration into scenario
             scenario = self.scenario_generator.parse_dsl_config(dsl_config.config_text)
+
+            if valkey_binary:
+                scenario.cluster_config.valkey_binary = valkey_binary
             
             # Validate scenario
             self.scenario_generator.validate_scenario(scenario)
@@ -92,7 +94,7 @@ class FuzzerEngine(IFuzzerEngine):
         start_time = time.time()
         operations_executed = 0
         chaos_events = []
-        validation_results = []  # Collect validation results for each operation
+        validation_results = []  # Collect validation results for each operation wave
         final_validation = None
         cluster_instance = None
         cluster_connection = None
@@ -143,9 +145,7 @@ class FuzzerEngine(IFuzzerEngine):
                 logger.debug("Using scenario-specific StateValidationConfig")
             else:
                 validation_config = StateValidationConfig()
-                # Allow 'unknown' state after failovers - it's transient and expected
-                validation_config.cluster_status_config.acceptable_states = ['ok', 'unknown']
-                logger.debug("Using default StateValidationConfig")
+                logger.info("Using default StateValidationConfig")
             
             # Adjust replication validation config based on cluster topology (for DSL scenarios)
             # If the cluster has no replicas, disable the min_replicas_per_shard check
@@ -165,11 +165,7 @@ class FuzzerEngine(IFuzzerEngine):
                 logger.info("Writing test data for data consistency validation")
                 test_data_written = state_validator.write_test_data(cluster_connection)
                 if not test_data_written:
-                    logger.warning("Failed to write test data - disabling data consistency validation for this run")
-                    state_validator.config.check_data_consistency = False
-            
-            # Track killed nodes for chaos-aware validation
-            killed_nodes_tracker = set()
+                    raise Exception("Failed to write test data required for data consistency validation")
             
             # Step 4: Execute operations in parallel with chaos coordination
             logger.info("")
@@ -177,37 +173,48 @@ class FuzzerEngine(IFuzzerEngine):
             logger.info("")
             
             parallel_executor = ParallelExecutor(self.operation_orchestrator, self.chaos_coordinator, self.logger)
+            expected_topology = self._build_expected_topology(scenario)
+
+            def validate_operation_wave(wave_number, wave_results):
+                wave_chaos_events = []
+                successful_operations = []
+                for _, _, chaos_events, _ in wave_results:
+                    wave_chaos_events.extend(chaos_events)
+                for op_index, executed, _, _ in wave_results:
+                    if executed:
+                        successful_operations.append(scenario.operations[op_index])
+
+                self._register_killed_nodes(
+                    state_validator,
+                    cluster_instance.nodes,
+                    wave_chaos_events
+                )
+
+                operation_context = None
+                if successful_operations:
+                    operation_context = LogValidationContext(operations=successful_operations)
+
+                validation_result = state_validator.validate_with_retry(
+                    cluster_connection,
+                    expected_topology,
+                    operation_context
+                )
+                self.logger.log_state_validation_result(validation_result, f"wave-{wave_number}")
+                return validation_result
             
             operations_executed, chaos_events, validation_results = parallel_executor.execute_operations_parallel(
                 scenario.operations,
                 scenario.chaos_config,
                 cluster_connection,
-                cluster_instance.cluster_id
+                cluster_instance.cluster_id,
+                validation_runner=validate_operation_wave,
+                halt_on_validation_failure=validation_config.blocking_on_failure
             )
-            
-            # Register killed nodes with state validator
-            for chaos_event in chaos_events:
-                if chaos_event.success and chaos_event.chaos_type == ChaosType.PROCESS_KILL:
-                    target_node_id = chaos_event.target_node
-                    target_role = chaos_event.target_role
-                    for node in cluster_instance.nodes:
-                        if node.node_id == target_node_id:
-                            node_address = f"{node.host}:{node.port}"
-                            state_validator.register_killed_node(node_address, target_role, node.shard_id)
-                            logger.info(f"Registered killed node for validation: {node_address} (role: {target_role}, shard: {node.shard_id})")
-                            break
             
             # Step 5: Final cluster validation
             logger.info("")
             logger.info("Step 5: Final cluster validation")
             logger.info("")
-            
-            # Build expected topology for final validation
-            expected_topology = ExpectedTopology(
-                num_primaries=scenario.cluster_config.num_shards,
-                num_replicas=scenario.cluster_config.num_shards * scenario.cluster_config.replicas_per_shard,
-                shard_structure={}
-            )
             
             # Execute final validation with retry (consistent with per-operation validation)
             # Create operation context for log validation - only include successful operations
@@ -238,9 +245,14 @@ class FuzzerEngine(IFuzzerEngine):
             self.logger.log_state_validation_result(final_validation_result, "final")
             
             # Determine overall success
-            # Success means: operations executed and validation passed
-            # Use the validation's overall_success which respects enabled/disabled checks
-            success = (operations_executed > 0 and final_validation_result.overall_success)
+            failure_reasons = self._collect_failure_reasons(
+                total_operations=len(scenario.operations),
+                operations_executed=operations_executed,
+                chaos_events=chaos_events,
+                validation_results=validation_results,
+                final_validation_result=final_validation_result
+            )
+            success = len(failure_reasons) == 0
             
             end_time = time.time()
             
@@ -252,6 +264,7 @@ class FuzzerEngine(IFuzzerEngine):
                 end_time=end_time,
                 operations_executed=operations_executed,
                 chaos_events=chaos_events,
+                error_message="; ".join(failure_reasons) if failure_reasons else None,
                 seed=scenario.seed,
                 validation_results=validation_results,
                 final_validation=final_validation
@@ -346,6 +359,74 @@ class FuzzerEngine(IFuzzerEngine):
         
         logger.info("Running standalone validation (data consistency check disabled - no test data)")
         return validator.validate_state(cluster_connection, expected_topology, None)
+
+    def _build_expected_topology(self, scenario: Scenario) -> ExpectedTopology:
+        """Build the expected topology for validation from the scenario."""
+        return ExpectedTopology(
+            num_primaries=scenario.cluster_config.num_shards,
+            num_replicas=scenario.cluster_config.num_shards * scenario.cluster_config.replicas_per_shard,
+            shard_structure={}
+        )
+
+    def _register_killed_nodes(
+        self,
+        state_validator: StateValidator,
+        cluster_nodes,
+        chaos_events: List
+    ) -> None:
+        """Register chaos-killed nodes so topology and health checks can reason about them."""
+        for chaos_event in chaos_events:
+            if not chaos_event.success or chaos_event.chaos_type != ChaosType.PROCESS_KILL:
+                continue
+
+            target_node_id = chaos_event.target_node
+            target_role = chaos_event.target_role
+            for node in cluster_nodes:
+                if node.node_id == target_node_id:
+                    node_address = f"{node.host}:{node.port}"
+                    state_validator.register_killed_node(node_address, target_role, node.shard_id)
+                    logger.info(
+                        f"Registered killed node for validation: {node_address} "
+                        f"(role: {target_role}, shard: {node.shard_id})"
+                    )
+                    break
+
+    def _collect_failure_reasons(
+        self,
+        total_operations: int,
+        operations_executed: int,
+        chaos_events: List,
+        validation_results: List,
+        final_validation_result
+    ) -> List[str]:
+        """Summarize all execution failures that should make the run fail."""
+        failure_reasons = []
+
+        if operations_executed != total_operations:
+            failed_operations = total_operations - operations_executed
+            failure_reasons.append(f"{failed_operations} operation(s) failed")
+
+        failed_chaos_events = [event for event in chaos_events if not event.success]
+        if failed_chaos_events:
+            failure_reasons.append(f"{len(failed_chaos_events)} chaos injection(s) failed")
+
+        if total_operations > 0 and not validation_results:
+            failure_reasons.append("post-operation validation did not run")
+        else:
+            failed_validation_waves = [
+                result for result in validation_results
+                if not result.overall_success
+            ]
+            if failed_validation_waves:
+                failure_reasons.append(
+                    f"{len(failed_validation_waves)} post-operation validation wave(s) failed"
+                )
+
+        if not final_validation_result.overall_success:
+            failed_checks = ", ".join(final_validation_result.failed_checks) or "unknown checks"
+            failure_reasons.append(f"final validation failed ({failed_checks})")
+
+        return failure_reasons
     
     def _create_cluster_with_retry(self, scenario: Scenario, max_retries: int = 3):
         """Create cluster with retry logic for failure recovery."""

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -145,7 +145,7 @@ class FuzzerEngine(IFuzzerEngine):
                 logger.debug("Using scenario-specific StateValidationConfig")
             else:
                 validation_config = StateValidationConfig()
-                logger.info("Using default StateValidationConfig")
+                logger.debug("Using default StateValidationConfig")
             
             # Adjust replication validation config based on cluster topology (for DSL scenarios)
             # If the cluster has no replicas, disable the min_replicas_per_shard check

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -420,7 +420,7 @@ class FuzzerEngine(IFuzzerEngine):
                     f"{len(failed_validation_waves)} post-operation validation wave(s) failed"
                 )
         elif total_operations > 0 and operations_executed == total_operations:
-        if not final_validation_result.overall_success:
+            failure_reasons.append("post-operation validation did not run")
 
         if not final_validation_result.overall_success:
             failed_checks = ", ".join(final_validation_result.failed_checks) or "unknown checks"

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -3,150 +3,171 @@ Parallel Executor - Executes multiple operations concurrently with buffered logg
 """
 import logging
 import time
-from typing import List, Tuple
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from ..models import Operation, ChaosConfig, ChaosResult
+from typing import Callable, List, Optional, Tuple
+
+from ..models import ChaosConfig, ChaosResult, Operation
 from .operation_log_buffer import OperationLogBuffer
 
 logger = logging.getLogger()
 
+
 class ParallelExecutor:
     """Executes operations in parallel by shard with per-operation log buffering"""
-    
+
     def __init__(self, operation_orchestrator, chaos_coordinator, fuzzer_logger):
         self.operation_orchestrator = operation_orchestrator
         self.chaos_coordinator = chaos_coordinator
         self.fuzzer_logger = fuzzer_logger
-    
-    def execute_operations_parallel(self, operations: List[Operation], chaos_config: ChaosConfig, cluster_connection, cluster_id: str) -> Tuple[int, List[ChaosResult], List]:
-        """Execute operations in parallel by shard with buffered logging"""
-        
+
+    def execute_operations_parallel(
+        self,
+        operations: List[Operation],
+        chaos_config: ChaosConfig,
+        cluster_connection,
+        cluster_id: str,
+        validation_runner: Optional[
+            Callable[[int, List[Tuple[int, int, List[ChaosResult], OperationLogBuffer]]], object]
+        ] = None,
+        halt_on_validation_failure: bool = False,
+    ) -> Tuple[int, List[ChaosResult], List]:
+        """Execute operations in parallel by shard, validating after each shard wave."""
         logger.info(f"Starting parallel execution of {len(operations)} operations")
-        
-        # Group operations by shard
+
+        if not operations:
+            return 0, [], []
+
         shard_groups = defaultdict(list)
-        for i, op in enumerate(operations):
-            shard_id = op.target_node.rsplit('-', 1)[0] if '-' in op.target_node else op.target_node
-            shard_groups[shard_id].append((i, op))
-        
+        for op_index, operation in enumerate(operations):
+            shard_id = operation.target_node.rsplit("-", 1)[0] if "-" in operation.target_node else operation.target_node
+            shard_groups[shard_id].append((op_index, operation))
+
         logger.info(f"Grouped {len(operations)} operations into {len(shard_groups)} shard groups")
-        
+
         operations_executed = 0
         all_chaos_events = []
-        results = [None] * len(operations)
-        
-        def _execute_shard_operations(shard_ops: List[Tuple[int, Operation]]):
-            """Execute all operations for a shard sequentially"""
-            shard_results = []
-            for op_index, operation in shard_ops:
-                op_id = f"{op_index + 1}: {operation.type.value} on {operation.target_node}"
-                buffer = OperationLogBuffer(op_id)
-                
-                try:
-                    buffer.info(f"Starting {operation.type.value}")
-                    
-                    # Coordinate chaos (may return deferred chaos for after-operation)
-                    chaos_results = self.chaos_coordinator.coordinate_chaos_with_operation(
-                        operation,
-                        chaos_config,
+        validation_results = []
+        ordered_shard_ids = list(shard_groups.keys())
+        total_waves = max(len(shard_ops) for shard_ops in shard_groups.values())
+
+        def execute_single_operation(op_index: int, operation: Operation):
+            """Execute one operation with chaos coordination and buffered logging."""
+            op_id = f"{op_index + 1}: {operation.type.value} on {operation.target_node}"
+            buffer = OperationLogBuffer(op_id)
+
+            try:
+                buffer.info(f"Starting {operation.type.value}")
+
+                chaos_results = self.chaos_coordinator.coordinate_chaos_with_operation(
+                    operation,
+                    chaos_config,
+                    cluster_connection,
+                    cluster_id,
+                    log_buffer=buffer,
+                )
+
+                immediate_chaos = [
+                    chaos for chaos in chaos_results
+                    if not isinstance(chaos, dict) or not chaos.get("deferred")
+                ]
+                deferred_chaos = [
+                    chaos for chaos in chaos_results
+                    if isinstance(chaos, dict) and chaos.get("deferred")
+                ]
+
+                success = self.operation_orchestrator.execute_operation(operation, log_buffer=buffer)
+
+                for deferred in deferred_chaos:
+                    buffer.info(f"Injecting deferred chaos after operation (delay: {deferred['delay']:.2f}s)")
+                    time.sleep(deferred["delay"])
+
+                    target_node = deferred["target_node"]
+                    live_nodes_dict = cluster_connection.get_live_nodes()
+                    if live_nodes_dict:
+                        for node_dict in live_nodes_dict:
+                            if node_dict["node_id"] == target_node.cluster_node_id:
+                                target_node.role = node_dict.get("role", target_node.role)
+                                buffer.debug(f"Refreshed target node role to: {target_node.role}")
+                                break
+
+                    result = self.chaos_coordinator._inject_chaos(
+                        target_node,
+                        deferred["chaos_config"],
+                        deferred["should_randomize"],
+                        buffer,
                         cluster_connection,
-                        cluster_id,
-                        log_buffer=buffer
                     )
-                    
-                    # Separate immediate and deferred chaos
-                    immediate_chaos = [c for c in chaos_results if not isinstance(c, dict) or not c.get('deferred')]
-                    deferred_chaos = [c for c in chaos_results if isinstance(c, dict) and c.get('deferred')]
-                    
-                    # Execute operation with buffered logging
-                    success = self.operation_orchestrator.execute_operation(operation, log_buffer=buffer)
-                    
-                    # Inject deferred chaos after operation completes
-                    for deferred in deferred_chaos:
-                        buffer.info(f"Injecting chaos after operation (delay: {deferred['delay']:.2f}s)")
-                        time.sleep(deferred['delay'])
-                        
-                        target_node = deferred['target_node']
-                        live_nodes_dict = cluster_connection.get_live_nodes()
-                        if live_nodes_dict:
-                            for node_dict in live_nodes_dict:
-                                if node_dict['node_id'] == target_node.cluster_node_id:
-                                    target_node.role = node_dict.get('role', target_node.role)
-                                    buffer.debug(f"Refreshed target node role to: {target_node.role}")
-                                    break
-                        
-                        result = self.chaos_coordinator._inject_chaos(
-                            target_node,
-                            deferred['chaos_config'],
-                            deferred['should_randomize'],
-                            buffer,
-                            cluster_connection
-                        )
-                        immediate_chaos.append(result)
-                        
-                        if isinstance(result, ChaosResult):
-                            self.chaos_coordinator.chaos_history.append(result)
-                    
-                    chaos_events = immediate_chaos
-                    
-                    # Log operation result
-                    self.fuzzer_logger.log_operation(
-                        operation,
-                        success,
-                        f"Operation {'succeeded' if success else 'failed'}",
-                        silent=False
-                    )
-                    
-                    # Log chaos events associated with this operation
-                    for chaos_event in chaos_events:
-                        if isinstance(chaos_event, ChaosResult):
-                            self.fuzzer_logger.log_chaos_event(chaos_event)
-                    
-                    buffer.info(f"Operation {'succeeded' if success else 'failed'}")
-                    
-                    shard_results.append((op_index, 1 if success else 0, chaos_events, buffer))
-                    
-                except Exception as e:
-                    buffer.error(f"Operation failed with exception: {e}")
-                    shard_results.append((op_index, 0, [], buffer))
-            
-            return shard_results
-        
-        # Execute shard groups in parallel
-        with ThreadPoolExecutor(max_workers=len(shard_groups)) as executor:
-            futures = {
-                executor.submit(_execute_shard_operations, shard_ops): shard_id
-                for shard_id, shard_ops in shard_groups.items()
-            }
-            
-            # Collect results from all shards
-            for future in as_completed(futures):
-                shard_id = futures[future]
-                try:
-                    shard_results = future.result()
-                    for op_index, executed, chaos_events, buffer in shard_results:
-                        results[op_index] = (executed, chaos_events, buffer)
-                except Exception as e:
-                    logger.error(f"Shard {shard_id} execution failed: {e}")
-                    # Mark all operations in this shard as failed
-                    shard_ops = shard_groups[shard_id]
-                    for op_index, operation in shard_ops:
-                        error_buffer = OperationLogBuffer(f"{op_index + 1}: {operation.type.value} on {operation.target_node}")
-                        error_buffer.error(f"Shard execution failed: {e}")
-                        results[op_index] = (0, [], error_buffer)
-        
-        # Flush logs in operation order
-        logger.info("")
-        logger.info("Operation Logs")
-        for result in results:
-            if result:
-                executed, chaos_events, buffer = result
+                    immediate_chaos.append(result)
+                    if isinstance(result, ChaosResult):
+                        self.chaos_coordinator.chaos_history.append(result)
+
+                chaos_events = immediate_chaos
+
+                self.fuzzer_logger.log_operation(
+                    operation,
+                    success,
+                    f"Operation {'succeeded' if success else 'failed'}",
+                    silent=False,
+                )
+                for chaos_event in chaos_events:
+                    if isinstance(chaos_event, ChaosResult):
+                        self.fuzzer_logger.log_chaos_event(chaos_event)
+
+                buffer.info(f"Operation {'succeeded' if success else 'failed'}")
+                return op_index, 1 if success else 0, chaos_events, buffer
+
+            except Exception as exc:
+                buffer.error(f"Operation failed with exception: {exc}")
+                return op_index, 0, [], buffer
+
+        for wave_index in range(total_waves):
+            wave_operations = []
+            for shard_id in ordered_shard_ids:
+                shard_ops = shard_groups[shard_id]
+                if wave_index < len(shard_ops):
+                    wave_operations.append(shard_ops[wave_index])
+
+            logger.info("")
+            logger.info(
+                f"Starting operation wave {wave_index + 1}/{total_waves} "
+                f"with {len(wave_operations)} operation(s)"
+            )
+
+            wave_results = []
+            with ThreadPoolExecutor(max_workers=len(wave_operations)) as executor:
+                futures = {
+                    executor.submit(execute_single_operation, op_index, operation): op_index
+                    for op_index, operation in wave_operations
+                }
+
+                for future in as_completed(futures):
+                    try:
+                        wave_results.append(future.result())
+                    except Exception as exc:
+                        op_index = futures[future]
+                        logger.error(f"Operation {op_index + 1} execution failed: {exc}")
+
+            wave_results.sort(key=lambda result: result[0])
+
+            logger.info("")
+            logger.info(f"Operation Logs - Wave {wave_index + 1}")
+            for _, executed, chaos_events, buffer in wave_results:
                 operations_executed += executed
                 all_chaos_events.extend(chaos_events)
                 buffer.flush()
-        
+
+            if validation_runner and wave_results:
+                validation_result = validation_runner(wave_index + 1, wave_results)
+                if validation_result is not None:
+                    validation_results.append(validation_result)
+                    if not validation_result.overall_success and (
+                        halt_on_validation_failure or validation_result.is_critical_failure()
+                    ):
+                        logger.error(
+                            f"Stopping execution after validation failure in wave {wave_index + 1}"
+                        )
+                        break
+
         logger.info(f"Parallel execution complete: {operations_executed}/{len(operations)} succeeded")
-        
-        return operations_executed, all_chaos_events, []
-    
+        return operations_executed, all_chaos_events, validation_results

--- a/src/main.py
+++ b/src/main.py
@@ -1,25 +1,33 @@
 """
 Main entry point for the Cluster Bus Fuzzer
 """
+from typing import Optional
+
 from .models import DSLConfig, ExecutionResult
 from .fuzzer_engine import FuzzerEngine
 
 
 class ClusterBusFuzzer:
     """Main orchestrator for the Cluster Bus Fuzzer"""
-    
+
     def __init__(self):
         """Initialize the fuzzer with the main fuzzer engine"""
         self.fuzzer_engine = FuzzerEngine()
         self.last_scenario = None
-    
-    def run_random_test(self, seed: int = None) -> ExecutionResult:
+
+    def run_random_test(self, seed: int = None, valkey_binary: Optional[str] = None) -> ExecutionResult:
         """Run a randomized test scenario."""
         scenario = self.fuzzer_engine.generate_random_scenario(seed)
+        if valkey_binary:
+            scenario.cluster_config.valkey_binary = valkey_binary
         result = self.fuzzer_engine.execute_test(scenario)
         self.last_scenario = scenario
         return result
-    
-    def run_dsl_test(self, dsl_config: DSLConfig) -> ExecutionResult:
+
+    def run_dsl_test(self, dsl_config: DSLConfig, valkey_binary: Optional[str] = None) -> ExecutionResult:
         """Run a DSL-based test scenario."""
-        return self.fuzzer_engine.execute_dsl_scenario(dsl_config)
+        return self.fuzzer_engine.execute_dsl_scenario(dsl_config, valkey_binary=valkey_binary)
+
+    def validate_cluster(self, cluster_id: str):
+        """Validate cluster state."""
+        return self.fuzzer_engine.validate_cluster_state(cluster_id)

--- a/src/models.py
+++ b/src/models.py
@@ -16,7 +16,7 @@ class ClusterConfig:
     replicas_per_shard: int
     base_port: int = 7000
     base_data_dir: str = "/tmp/valkey-fuzzer"
-    valkey_binary: str = "/usr/local/bin/valkey-server"
+    valkey_binary: str = ""
     enable_cleanup: bool = True
 
 

--- a/tests/test_chaos_coordinator.py
+++ b/tests/test_chaos_coordinator.py
@@ -390,7 +390,55 @@ def test_coordinate_chaos_with_operation_no_target(mock_sleep):
     # Empty node list - no target will be found
     results = coordinator.coordinate_chaos_with_operation(operation, chaos_config, mock_connection, "test_cluster")
     
-    assert len(results) == 0
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].chaos_type == ChaosType.PROCESS_KILL
+    assert results[0].target_node == "node-0"
+    assert "No suitable chaos target found" in results[0].error_message
+    assert coordinator.chaos_history == results
+
+
+@patch('src.fuzzer_engine.chaos_coordinator.time.sleep')
+def test_coordinate_chaos_with_operation_returns_failure_result_on_exception(mock_sleep):
+    """Test that unexpected coordination exceptions become explicit failed chaos results"""
+    coordinator = ChaosCoordinator()
+
+    operation = Operation(
+        type=OperationType.FAILOVER,
+        target_node="node-0",
+        parameters={},
+        timing=OperationTiming()
+    )
+
+    chaos_config = ChaosConfig(
+        chaos_type=ChaosType.PROCESS_KILL,
+        target_selection=TargetSelection(strategy="random"),
+        timing=ChaosTiming(),
+        coordination=ChaosCoordination(chaos_during_operation=True),
+        process_chaos_type=ProcessChaosType.SIGKILL
+    )
+
+    mock_connection = MagicMock()
+    mock_connection.get_live_nodes.return_value = []
+    mock_connection.initial_nodes = []
+
+    with patch.object(
+        coordinator.chaos_engine.target_selector,
+        'select_target',
+        side_effect=RuntimeError("selector exploded")
+    ):
+        results = coordinator.coordinate_chaos_with_operation(
+            operation,
+            chaos_config,
+            mock_connection,
+            "test_cluster"
+        )
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].target_node == "node-0"
+    assert "selector exploded" in results[0].error_message
+    assert coordinator.chaos_history == results
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -469,6 +469,23 @@ class TestCLIMain:
         
         assert result == 0
         mock_cli.run_dsl_test.assert_called_once()
+        dsl_args = mock_cli.run_dsl_test.call_args.args[0]
+        assert dsl_args.valkey_binary is None
+
+    @patch('src.cli.FuzzerCLI')
+    def test_main_dsl_command_with_valkey_binary(self, mock_cli_class):
+        """Test main with DSL command and explicit Valkey binary"""
+        mock_cli = Mock()
+        mock_cli.run_dsl_test.return_value = 0
+        mock_cli_class.return_value = mock_cli
+
+        with patch('sys.argv', ['cli', 'cluster', '--dsl', 'test.yaml', '--valkey-binary', '/tmp/valkey-server']):
+            result = main()
+
+        assert result == 0
+        mock_cli.run_dsl_test.assert_called_once()
+        dsl_args = mock_cli.run_dsl_test.call_args.args[0]
+        assert dsl_args.valkey_binary == '/tmp/valkey-server'
     
     @patch('src.cli.FuzzerCLI')
     def test_main_validate_command(self, mock_cli_class):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,7 @@ class TestFuzzerCLI:
             seed=42,
             iterations=1,
             config=None,
+            valkey_binary=None,
             output=None,
             verbose=False,
             export_dsl=None
@@ -128,6 +129,7 @@ class TestFuzzerCLI:
             seed=None,
             iterations=1,
             config=str(config_file),
+            valkey_binary=None,
             output=None,
             verbose=False,
             export_dsl=None
@@ -151,6 +153,7 @@ class TestFuzzerCLI:
             seed=42,
             iterations=3,
             config=None,
+            valkey_binary=None,
             output=None,
             verbose=False,
             export_dsl=None
@@ -176,6 +179,7 @@ class TestFuzzerCLI:
             seed=42,
             iterations=1,
             config=None,
+            valkey_binary=None,
             output=str(output_file),
             format='json',
             verbose=False,
@@ -211,6 +215,7 @@ class TestFuzzerCLI:
             seed=42,
             iterations=1,
             config=None,
+            valkey_binary=None,
             output=None,
             verbose=False,
             export_dsl=str(export_file)
@@ -238,6 +243,7 @@ class TestFuzzerCLI:
         cli = FuzzerCLI()
         args = Mock(
             file=str(dsl_file),
+            valkey_binary=None,
             output=None,
             verbose=False
         )
@@ -247,6 +253,63 @@ class TestFuzzerCLI:
         assert result == 0
         mock_loader.load_from_file.assert_called_once_with(str(dsl_file))
         mock_fuzzer.run_dsl_test.assert_called_once_with(mock_dsl_config)
+
+    @patch('src.cli.ClusterBusFuzzer')
+    def test_run_random_test_passes_valkey_binary(self, mock_fuzzer_class, mock_result):
+        """Test running random test with explicit Valkey binary override"""
+        mock_fuzzer = Mock()
+        mock_fuzzer.run_random_test.return_value = mock_result
+        mock_fuzzer.last_scenario = Mock()
+        mock_fuzzer_class.return_value = mock_fuzzer
+
+        cli = FuzzerCLI()
+        args = Mock(
+            seed=42,
+            iterations=1,
+            config=None,
+            valkey_binary="/tmp/valkey/src/valkey-server",
+            output=None,
+            verbose=False,
+            export_dsl=None
+        )
+
+        result = cli.run_random_test(args)
+
+        assert result == 0
+        mock_fuzzer.run_random_test.assert_called_once_with(
+            seed=42,
+            valkey_binary="/tmp/valkey/src/valkey-server"
+        )
+
+    @patch('src.cli.ClusterBusFuzzer')
+    @patch('src.cli.DSLLoader')
+    def test_run_dsl_test_passes_valkey_binary(self, mock_loader, mock_fuzzer_class, mock_result, tmp_path):
+        """Test running DSL test with explicit Valkey binary override"""
+        dsl_file = tmp_path / "test.yaml"
+        dsl_file.write_text("scenario:\n  id: test\n")
+
+        mock_dsl_config = Mock()
+        mock_loader.load_from_file.return_value = mock_dsl_config
+
+        mock_fuzzer = Mock()
+        mock_fuzzer.run_dsl_test.return_value = mock_result
+        mock_fuzzer_class.return_value = mock_fuzzer
+
+        cli = FuzzerCLI()
+        args = Mock(
+            file=str(dsl_file),
+            valkey_binary="/tmp/valkey/src/valkey-server",
+            output=None,
+            verbose=False
+        )
+
+        result = cli.run_dsl_test(args)
+
+        assert result == 0
+        mock_fuzzer.run_dsl_test.assert_called_once_with(
+            mock_dsl_config,
+            valkey_binary="/tmp/valkey/src/valkey-server"
+        )
     
     @patch('src.cli.ClusterBusFuzzer')
     def test_run_dsl_test_file_not_found(self, mock_fuzzer_class, capsys):
@@ -351,6 +414,14 @@ class TestCLIParser:
         
         assert args.command == 'cluster'
         assert args.dsl == 'test.yaml'
+
+    def test_parse_valkey_binary_option(self):
+        """Test parsing explicit Valkey binary option"""
+        parser = create_parser()
+        args = parser.parse_args(['cluster', '--random', '--valkey-binary', '/tmp/valkey-server'])
+
+        assert args.command == 'cluster'
+        assert args.valkey_binary == '/tmp/valkey-server'
     
     def test_parse_output_options(self):
         """Test parsing output options"""

--- a/tests/test_fuzzer_engine_strictness.py
+++ b/tests/test_fuzzer_engine_strictness.py
@@ -1,0 +1,347 @@
+"""
+Unit tests for strict run success criteria and wave validation behavior.
+"""
+import time
+from unittest.mock import Mock, patch
+
+from src.fuzzer_engine.fuzzer_engine import FuzzerEngine
+from src.fuzzer_engine.parallel_executor import ParallelExecutor
+from src.models import (
+    ChaosConfig,
+    ChaosCoordination,
+    ChaosResult,
+    ChaosTiming,
+    ChaosType,
+    ClusterConfig,
+    ClusterStatusValidation,
+    ExecutionResult,
+    Operation,
+    OperationTiming,
+    OperationType,
+    ProcessChaosType,
+    Scenario,
+    StateValidationResult,
+    TargetSelection,
+)
+
+
+def build_scenario() -> Scenario:
+    return Scenario(
+        scenario_id="strict-test",
+        cluster_config=ClusterConfig(num_shards=3, replicas_per_shard=1),
+        operations=[
+            Operation(
+                type=OperationType.FAILOVER,
+                target_node="shard-0-primary",
+                parameters={"force": False},
+                timing=OperationTiming(),
+            ),
+            Operation(
+                type=OperationType.FAILOVER,
+                target_node="shard-1-primary",
+                parameters={"force": False},
+                timing=OperationTiming(),
+            ),
+        ],
+        chaos_config=ChaosConfig(
+            chaos_type=ChaosType.PROCESS_KILL,
+            target_selection=TargetSelection(strategy="random"),
+            timing=ChaosTiming(),
+            coordination=ChaosCoordination(),
+            process_chaos_type=ProcessChaosType.SIGKILL,
+        ),
+    )
+
+
+def build_validation_result(
+    overall_success: bool,
+    failed_checks=None,
+    cluster_state: str = "ok",
+) -> StateValidationResult:
+    failed_checks = failed_checks or []
+    error_messages = [f"{check} failed" for check in failed_checks]
+
+    cluster_status = ClusterStatusValidation(
+        success=overall_success,
+        cluster_state=cluster_state,
+        nodes_in_fail_state=[],
+        has_quorum=True,
+        degraded_reason=None,
+        error_message=", ".join(error_messages) if error_messages else None,
+    )
+
+    return StateValidationResult(
+        overall_success=overall_success,
+        validation_timestamp=time.time(),
+        validation_duration=0.5,
+        replication=None,
+        cluster_status=cluster_status,
+        slot_coverage=None,
+        topology=None,
+        view_consistency=None,
+        data_consistency=None,
+        failed_checks=failed_checks,
+        error_messages=error_messages,
+    )
+
+
+def build_cluster_instance():
+    node = Mock()
+    node.node_id = "node-0"
+    node.host = "127.0.0.1"
+    node.port = 7000
+    return Mock(cluster_id="cluster-1", nodes=[node])
+
+
+@patch("src.fuzzer_engine.fuzzer_engine.load_all_slots")
+@patch("src.fuzzer_engine.fuzzer_engine.StateValidator")
+@patch("src.fuzzer_engine.fuzzer_engine.ClusterConnection")
+@patch("src.fuzzer_engine.fuzzer_engine.ParallelExecutor")
+def test_execute_test_fails_when_not_all_operations_succeed(
+    mock_executor_class,
+    mock_connection_class,
+    mock_validator_class,
+    mock_load_all_slots,
+):
+    engine = FuzzerEngine()
+    scenario = build_scenario()
+    cluster_instance = build_cluster_instance()
+
+    engine._create_cluster_with_retry = Mock(return_value=cluster_instance)
+    engine._validate_cluster_readiness_with_retry = Mock(return_value=True)
+    engine._cleanup_resources = Mock()
+
+    mock_connection = Mock()
+    mock_connection_class.return_value = mock_connection
+
+    mock_validator = Mock()
+    mock_validator.write_test_data.return_value = True
+    mock_validator.validate_with_retry.return_value = build_validation_result(True)
+    mock_validator_class.return_value = mock_validator
+
+    mock_executor = Mock()
+    mock_executor.execute_operations_parallel.return_value = (
+        1,
+        [],
+        [build_validation_result(True)],
+    )
+    mock_executor_class.return_value = mock_executor
+
+    result = engine.execute_test(scenario)
+
+    assert result.success is False
+    assert result.error_message == "1 operation(s) failed"
+
+
+@patch("src.fuzzer_engine.fuzzer_engine.load_all_slots")
+@patch("src.fuzzer_engine.fuzzer_engine.StateValidator")
+@patch("src.fuzzer_engine.fuzzer_engine.ClusterConnection")
+@patch("src.fuzzer_engine.fuzzer_engine.ParallelExecutor")
+def test_execute_test_fails_when_post_operation_validation_fails(
+    mock_executor_class,
+    mock_connection_class,
+    mock_validator_class,
+    mock_load_all_slots,
+):
+    engine = FuzzerEngine()
+    scenario = build_scenario()
+    cluster_instance = build_cluster_instance()
+
+    engine._create_cluster_with_retry = Mock(return_value=cluster_instance)
+    engine._validate_cluster_readiness_with_retry = Mock(return_value=True)
+    engine._cleanup_resources = Mock()
+
+    mock_connection_class.return_value = Mock()
+
+    mock_validator = Mock()
+    mock_validator.write_test_data.return_value = True
+    mock_validator.validate_with_retry.return_value = build_validation_result(True)
+    mock_validator_class.return_value = mock_validator
+
+    mock_executor = Mock()
+    mock_executor.execute_operations_parallel.return_value = (
+        len(scenario.operations),
+        [],
+        [build_validation_result(False, failed_checks=["replication"])],
+    )
+    mock_executor_class.return_value = mock_executor
+
+    result = engine.execute_test(scenario)
+
+    assert result.success is False
+    assert "post-operation validation wave(s) failed" in result.error_message
+
+
+@patch("src.fuzzer_engine.fuzzer_engine.load_all_slots")
+@patch("src.fuzzer_engine.fuzzer_engine.StateValidator")
+@patch("src.fuzzer_engine.fuzzer_engine.ClusterConnection")
+@patch("src.fuzzer_engine.fuzzer_engine.ParallelExecutor")
+def test_execute_test_fails_when_chaos_injection_fails(
+    mock_executor_class,
+    mock_connection_class,
+    mock_validator_class,
+    mock_load_all_slots,
+):
+    engine = FuzzerEngine()
+    scenario = build_scenario()
+    cluster_instance = build_cluster_instance()
+
+    engine._create_cluster_with_retry = Mock(return_value=cluster_instance)
+    engine._validate_cluster_readiness_with_retry = Mock(return_value=True)
+    engine._cleanup_resources = Mock()
+
+    mock_connection_class.return_value = Mock()
+
+    mock_validator = Mock()
+    mock_validator.write_test_data.return_value = True
+    mock_validator.validate_with_retry.return_value = build_validation_result(True)
+    mock_validator_class.return_value = mock_validator
+
+    failed_chaos = ChaosResult(
+        chaos_id="chaos-1",
+        chaos_type=ChaosType.PROCESS_KILL,
+        target_node="node-0",
+        success=False,
+        start_time=time.time(),
+        end_time=time.time(),
+        error_message="kill failed",
+    )
+
+    mock_executor = Mock()
+    mock_executor.execute_operations_parallel.return_value = (
+        len(scenario.operations),
+        [failed_chaos],
+        [build_validation_result(True)],
+    )
+    mock_executor_class.return_value = mock_executor
+
+    result = engine.execute_test(scenario)
+
+    assert result.success is False
+    assert result.error_message == "1 chaos injection(s) failed"
+
+
+@patch("src.fuzzer_engine.fuzzer_engine.load_all_slots")
+@patch("src.fuzzer_engine.fuzzer_engine.StateValidator")
+@patch("src.fuzzer_engine.fuzzer_engine.ClusterConnection")
+@patch("src.fuzzer_engine.fuzzer_engine.ParallelExecutor")
+def test_execute_test_fails_when_data_consistency_setup_fails(
+    mock_executor_class,
+    mock_connection_class,
+    mock_validator_class,
+    mock_load_all_slots,
+):
+    engine = FuzzerEngine()
+    scenario = build_scenario()
+    cluster_instance = build_cluster_instance()
+
+    engine._create_cluster_with_retry = Mock(return_value=cluster_instance)
+    engine._validate_cluster_readiness_with_retry = Mock(return_value=True)
+    engine._cleanup_resources = Mock()
+
+    mock_connection_class.return_value = Mock()
+
+    mock_validator = Mock()
+    mock_validator.write_test_data.return_value = False
+    mock_validator_class.return_value = mock_validator
+
+    result = engine.execute_test(scenario)
+
+    assert result.success is False
+    assert "Failed to write test data required for data consistency validation" in result.error_message
+    mock_executor_class.assert_not_called()
+
+
+@patch("src.fuzzer_engine.fuzzer_engine.load_all_slots")
+@patch("src.fuzzer_engine.fuzzer_engine.StateValidator")
+@patch("src.fuzzer_engine.fuzzer_engine.ClusterConnection")
+@patch("src.fuzzer_engine.fuzzer_engine.ParallelExecutor")
+def test_execute_test_keeps_default_cluster_state_validation_strict(
+    mock_executor_class,
+    mock_connection_class,
+    mock_validator_class,
+    mock_load_all_slots,
+):
+    engine = FuzzerEngine()
+    scenario = build_scenario()
+    cluster_instance = build_cluster_instance()
+
+    engine._create_cluster_with_retry = Mock(return_value=cluster_instance)
+    engine._validate_cluster_readiness_with_retry = Mock(return_value=True)
+    engine._cleanup_resources = Mock()
+
+    mock_connection_class.return_value = Mock()
+
+    mock_validator = Mock()
+    mock_validator.write_test_data.return_value = True
+    mock_validator.validate_with_retry.return_value = build_validation_result(True)
+    mock_validator_class.return_value = mock_validator
+
+    mock_executor = Mock()
+    mock_executor.execute_operations_parallel.return_value = (
+        len(scenario.operations),
+        [],
+        [build_validation_result(True)],
+    )
+    mock_executor_class.return_value = mock_executor
+
+    engine.execute_test(scenario)
+
+    config = mock_validator_class.call_args[0][0]
+    assert config.cluster_status_config.acceptable_states == ["ok"]
+
+
+def test_parallel_executor_runs_validation_after_each_wave():
+    operation_orchestrator = Mock()
+    operation_orchestrator.execute_operation.return_value = True
+
+    chaos_coordinator = Mock()
+    chaos_coordinator.coordinate_chaos_with_operation.return_value = []
+
+    fuzzer_logger = Mock()
+    executor = ParallelExecutor(operation_orchestrator, chaos_coordinator, fuzzer_logger)
+
+    operations = [
+        Operation(
+            type=OperationType.FAILOVER,
+            target_node="shard-0-primary",
+            parameters={},
+            timing=OperationTiming(),
+        ),
+        Operation(
+            type=OperationType.FAILOVER,
+            target_node="shard-1-primary",
+            parameters={},
+            timing=OperationTiming(),
+        ),
+        Operation(
+            type=OperationType.FAILOVER,
+            target_node="shard-0-primary",
+            parameters={},
+            timing=OperationTiming(),
+        ),
+    ]
+
+    validation_runner = Mock(side_effect=[
+        build_validation_result(True),
+        build_validation_result(True),
+    ])
+
+    operations_executed, chaos_events, validation_results = executor.execute_operations_parallel(
+        operations,
+        build_scenario().chaos_config,
+        Mock(get_live_nodes=Mock(return_value=[])),
+        "cluster-1",
+        validation_runner=validation_runner,
+    )
+
+    assert operations_executed == 3
+    assert chaos_events == []
+    assert len(validation_results) == 2
+    assert validation_runner.call_count == 2
+
+    first_wave_results = validation_runner.call_args_list[0].args[1]
+    second_wave_results = validation_runner.call_args_list[1].args[1]
+
+    assert [result[0] for result in first_wave_results] == [0, 1]
+    assert [result[0] for result in second_wave_results] == [2]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -68,8 +68,9 @@ def test_configuration_manager_topology():
         assert primary.slot_start <= primary.slot_end
 
 
-@patch('src.cluster_orchestrator.orchestrator.shutil.which')
-def test_setup_valkey_from_source_uses_configured_binary(mock_which):
+@patch('os.access', return_value=True)
+@patch('os.path.isfile', return_value=True)
+def test_setup_valkey_from_source_uses_configured_binary(mock_isfile, mock_access):
     """Test that an explicit Valkey binary path is preferred when it exists"""
     config = ClusterConfig(
         num_shards=3,
@@ -78,16 +79,14 @@ def test_setup_valkey_from_source_uses_configured_binary(mock_which):
     )
     config_mgr = ConfigurationManager(config, PortManager())
 
-    mock_which.side_effect = ['/tmp/valkey/src/valkey-server']
-
     valkey_binary = config_mgr.setup_valkey_from_source()
 
     assert valkey_binary == '/tmp/valkey/src/valkey-server'
-    assert mock_which.call_args_list[0].args == ('/tmp/valkey/src/valkey-server',)
+    mock_isfile.assert_called_once_with('/tmp/valkey/src/valkey-server')
 
 
-@patch('src.cluster_orchestrator.orchestrator.shutil.which')
-def test_setup_valkey_from_source_fails_when_configured_binary_missing(mock_which):
+@patch('os.path.isfile', return_value=False)
+def test_setup_valkey_from_source_fails_when_configured_binary_missing(mock_isfile):
     """Test that setup raises when the configured binary cannot be resolved"""
     config = ClusterConfig(
         num_shards=3,
@@ -95,8 +94,6 @@ def test_setup_valkey_from_source_fails_when_configured_binary_missing(mock_whic
         valkey_binary='/tmp/missing-valkey-server'
     )
     config_mgr = ConfigurationManager(config, PortManager())
-
-    mock_which.return_value = None
 
     with pytest.raises(FileNotFoundError, match="missing-valkey-server"):
         config_mgr.setup_valkey_from_source()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -86,10 +86,9 @@ def test_setup_valkey_from_source_uses_configured_binary(mock_which):
     assert mock_which.call_args_list[0].args == ('/tmp/valkey/src/valkey-server',)
 
 
-@patch('src.cluster_orchestrator.orchestrator.subprocess.run')
 @patch('src.cluster_orchestrator.orchestrator.shutil.which')
-def test_setup_valkey_from_source_falls_back_to_path_binary(mock_which, mock_run):
-    """Test that setup falls back to PATH when the configured binary is unavailable"""
+def test_setup_valkey_from_source_fails_when_configured_binary_missing(mock_which):
+    """Test that setup raises when the configured binary cannot be resolved"""
     config = ClusterConfig(
         num_shards=3,
         replicas_per_shard=1,
@@ -97,12 +96,10 @@ def test_setup_valkey_from_source_falls_back_to_path_binary(mock_which, mock_run
     )
     config_mgr = ConfigurationManager(config, PortManager())
 
-    mock_which.side_effect = [None, '/usr/local/bin/valkey-server']
+    mock_which.return_value = None
 
-    valkey_binary = config_mgr.setup_valkey_from_source()
-
-    assert valkey_binary == '/usr/local/bin/valkey-server'
-    mock_run.assert_not_called()
+    with pytest.raises(FileNotFoundError, match="missing-valkey-server"):
+        config_mgr.setup_valkey_from_source()
 
 
 def test_full_cluster_creation():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,5 +1,6 @@
 import pytest
 import logging
+from unittest.mock import patch
 from src.cluster_orchestrator.orchestrator import PortManager, ConfigurationManager, ClusterManager
 from src.models import ClusterConfig
 
@@ -65,6 +66,43 @@ def test_configuration_manager_topology():
         assert primary.slot_start is not None
         assert primary.slot_end is not None
         assert primary.slot_start <= primary.slot_end
+
+
+@patch('src.cluster_orchestrator.orchestrator.shutil.which')
+def test_setup_valkey_from_source_uses_configured_binary(mock_which):
+    """Test that an explicit Valkey binary path is preferred when it exists"""
+    config = ClusterConfig(
+        num_shards=3,
+        replicas_per_shard=1,
+        valkey_binary='/tmp/valkey/src/valkey-server'
+    )
+    config_mgr = ConfigurationManager(config, PortManager())
+
+    mock_which.side_effect = ['/tmp/valkey/src/valkey-server']
+
+    valkey_binary = config_mgr.setup_valkey_from_source()
+
+    assert valkey_binary == '/tmp/valkey/src/valkey-server'
+    assert mock_which.call_args_list[0].args == ('/tmp/valkey/src/valkey-server',)
+
+
+@patch('src.cluster_orchestrator.orchestrator.subprocess.run')
+@patch('src.cluster_orchestrator.orchestrator.shutil.which')
+def test_setup_valkey_from_source_falls_back_to_path_binary(mock_which, mock_run):
+    """Test that setup falls back to PATH when the configured binary is unavailable"""
+    config = ClusterConfig(
+        num_shards=3,
+        replicas_per_shard=1,
+        valkey_binary='/tmp/missing-valkey-server'
+    )
+    config_mgr = ConfigurationManager(config, PortManager())
+
+    mock_which.side_effect = [None, '/usr/local/bin/valkey-server']
+
+    valkey_binary = config_mgr.setup_valkey_from_source()
+
+    assert valkey_binary == '/usr/local/bin/valkey-server'
+    mock_run.assert_not_called()
 
 
 def test_full_cluster_creation():


### PR DESCRIPTION
## Summary
- add a reusable/manual GitHub Actions workflow to build a Valkey PR merge ref once and fan out 10 random fuzzer runs
- add explicit `--valkey-binary` support so workflow jobs run against the exact built Valkey binary
- make run success strict: fail if any operation fails, any chaos injection fails, any post-operation validation wave fails, or final validation fails
- validate after each parallel operation wave and surface post-operation/final validation details in workflow artifacts and summary
- document the Valkey-side label-trigger workflow and add focused regression coverage

## Testing
- `pytest tests/test_fuzzer_engine_strictness.py tests/test_state_validator.py tests/test_cli.py tests/test_orchestrator.py -q -k "not full_cluster_creation and not large"`
- `python -m compileall src tests/test_fuzzer_engine_strictness.py`
- workflow YAML parse check for `.github/workflows/pr-merge-fuzzer.yml`

## Notes
- the new workflow remains in the fuzzer repo, but the label-trigger entrypoint still needs to live in the `valkey` repo because that is where the PR event originates
- unrelated untracked local files were intentionally left out of this branch
