### PR TITLE
Add shared library support for Valkey PR fuzzer workflow

### DIFF
--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,8 +224,7 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          sudo make install PREFIX=/usr/local
-          valkey-server --version
+          src/valkey-server --version
 
       - name: Capture resolved SHA
         id: commit
@@ -235,12 +234,12 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          cp /usr/local/bin/valkey-server valkey-binaries/
-          cp /usr/local/bin/valkey-cli valkey-binaries/
-          cp /usr/local/bin/valkey-benchmark valkey-binaries/
+          cp valkey-src/src/valkey-server valkey-binaries/
+          cp valkey-src/src/valkey-cli valkey-binaries/
+          cp valkey-src/src/valkey-benchmark valkey-binaries/
           
-          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
-            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
+          if [ -f valkey-src/src/libvalkeylua.so ]; then
+            cp valkey-src/src/libvalkeylua.so valkey-binaries/
           fi
           
           ls -la valkey-binaries/
@@ -286,7 +285,10 @@ jobs:
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
             sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
+            echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/usrlocal.conf
             sudo ldconfig
+            echo "Library installed and ldconfig run:"
+            ldconfig -p | grep valkeylua || echo "Warning: libvalkeylua.so not found in ldconfig cache"
           fi
 
       - name: Set up Python

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -237,7 +237,10 @@ jobs:
           cp valkey-src/src/valkey-server valkey-binaries/
           cp valkey-src/src/valkey-cli valkey-binaries/
           cp valkey-src/src/valkey-benchmark valkey-binaries/
-          cp valkey-src/src/modules/lua/libvalkeylua.so valkey-binaries/
+          
+          if [ -f valkey-src/src/modules/lua/libvalkeylua.so ]; then
+            cp valkey-src/src/modules/lua/libvalkeylua.so valkey-binaries/
+          fi
 
       - name: Upload Valkey binaries
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,7 +224,8 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          src/valkey-server --version
+          sudo make install PREFIX=/usr/local
+          valkey-server --version
 
       - name: Capture resolved SHA
         id: commit
@@ -234,12 +235,12 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          cp valkey-src/src/valkey-server valkey-binaries/
-          cp valkey-src/src/valkey-cli valkey-binaries/
-          cp valkey-src/src/valkey-benchmark valkey-binaries/
+          cp /usr/local/bin/valkey-server valkey-binaries/
+          cp /usr/local/bin/valkey-cli valkey-binaries/
+          cp /usr/local/bin/valkey-benchmark valkey-binaries/
           
-          if [ -f valkey-src/src/libvalkeylua.so ]; then
-            cp valkey-src/src/libvalkeylua.so valkey-binaries/
+          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
+            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
           fi
           
           ls -la valkey-binaries/
@@ -281,6 +282,7 @@ jobs:
       - name: Install Valkey binaries
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
+          sudo cp "${{ runner.temp }}/valkey-binaries/valkey-"* /usr/local/bin/
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
             sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
@@ -298,7 +300,7 @@ jobs:
         env:
           RUN_ID: ${{ matrix.run_id }}
           RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
-          VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
+          VALKEY_BINARY: /usr/local/bin/valkey-server
         run: |
           set +e
 

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -281,14 +281,9 @@ jobs:
       - name: Install Valkey binaries
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          mkdir -p "$HOME/.local/bin"
-          cp "${{ runner.temp }}/valkey-binaries/valkey-"* "$HOME/.local/bin/"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            mkdir -p "$HOME/.local/lib"
-            cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" "$HOME/.local/lib/"
-            echo "LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+            echo "LD_LIBRARY_PATH=${{ runner.temp }}/valkey-binaries:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
           fi
 
       - name: Set up Python

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -227,27 +227,18 @@ jobs:
           
           # Check what .so files were built
           echo "Checking for shared libraries:"
-          ls -la src/*.so 2>/dev/null || echo "No .so files found in src/"
+          find src -name "*.so" -type f
           
-          # Install binaries
+          # Install binaries and libraries
           sudo make install PREFIX=/usr/local
-          
-          # Explicitly copy any .so files to system library path
-          if ls src/*.so 1> /dev/null 2>&1; then
-            echo "Installing shared libraries to /usr/local/lib/"
-            sudo cp -v src/*.so /usr/local/lib/
-            sudo ldconfig
-            echo "Shared libraries installed and ldconfig updated"
-          else
-            echo "No shared libraries to install"
-          fi
           
           # Verify installation
           echo "Verifying valkey-server installation:"
           which valkey-server
           valkey-server --version
-          echo "Checking library dependencies:"
-          ldd /usr/local/bin/valkey-server | grep -i lua || echo "No lua library dependency found"
+          
+          echo "Checking installed .so files:"
+          find /usr/local -name "*.so" -type f 2>/dev/null | grep valkey || echo "No valkey .so files found"
 
       - name: Capture resolved SHA
         id: commit
@@ -257,9 +248,20 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
+          
+          # Copy binaries
           cp /usr/local/bin/valkey-server valkey-binaries/
           cp /usr/local/bin/valkey-cli valkey-binaries/
           cp /usr/local/bin/valkey-benchmark valkey-binaries/
+          
+          # Find and copy any installed .so files
+          echo "Looking for installed .so files:"
+          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
+            find /usr/local -name "libvalkeylua.so" -type f -exec cp -v {} valkey-binaries/ \;
+          fi
+          
+          echo "Artifact contents:"
+          ls -la valkey-binaries/
 
       - name: Upload Valkey binaries
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -298,17 +300,24 @@ jobs:
       - name: Install Valkey binaries
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          sudo cp "${{ runner.temp }}/valkey-binaries/"* /usr/local/bin/
+          
+          # Install binaries
+          sudo cp "${{ runner.temp }}/valkey-binaries/valkey-"* /usr/local/bin/
+          
+          # Install .so files if present
+          if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
+            echo "Installing libvalkeylua.so"
+            sudo mkdir -p /usr/local/lib/valkey/modules/lua
+            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/valkey/modules/lua/
+            sudo ldconfig
+          fi
           
           # Verify what was installed
           echo "Installed binaries:"
           ls -la /usr/local/bin/valkey-*
           
-          echo "Checking library dependencies:"
-          ldd /usr/local/bin/valkey-server | grep -i lua || echo "No lua library dependency found"
-          
-          echo "Checking /usr/local/lib/ for .so files:"
-          ls -la /usr/local/lib/*.so 2>/dev/null || echo "No .so files in /usr/local/lib/"
+          echo "Installed libraries:"
+          find /usr/local/lib -name "*.so" 2>/dev/null | grep valkey || echo "No valkey .so files found"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -231,16 +231,13 @@ jobs:
         working-directory: valkey-src
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Package installed binaries
+      - name: Package Valkey binaries
         run: |
           mkdir -p valkey-binaries
           cp valkey-src/src/valkey-server valkey-binaries/
           cp valkey-src/src/valkey-cli valkey-binaries/
           cp valkey-src/src/valkey-benchmark valkey-binaries/
           cp valkey-src/src/modules/lua/libvalkeylua.so valkey-binaries/
-          
-          echo "Packaged binaries:"
-          ls -la valkey-binaries/
 
       - name: Upload Valkey binaries
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -277,20 +274,7 @@ jobs:
           path: ${{ runner.temp }}/valkey-binaries
 
       - name: Install Valkey binaries
-        run: |
-          echo "=== Valkey binaries setup ==="
-          chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          
-          echo "Binaries in temp directory:"
-          ls -la "${{ runner.temp }}/valkey-binaries/"
-          
-          if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            echo "✓ libvalkeylua.so found in binaries"
-          else
-            echo "✗ libvalkeylua.so NOT found in binaries"
-          fi
-          
-          echo "=== Setup complete ==="
+        run: chmod +x "${{ runner.temp }}/valkey-binaries/"*
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -307,18 +291,6 @@ jobs:
           LD_LIBRARY_PATH: ${{ runner.temp }}/valkey-binaries
         run: |
           set +e
-          
-          echo "=== Environment check ==="
-          echo "VALKEY_BINARY: ${VALKEY_BINARY}"
-          echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-          
-          echo "Testing valkey-server directly:"
-          "${VALKEY_BINARY}" --version || echo "Failed to run valkey-server --version"
-          
-          echo "Checking library dependencies:"
-          ldd "${VALKEY_BINARY}" | grep valkeylua || echo "libvalkeylua.so not in dependencies or not found"
-          
-          echo "=== Starting fuzzer ==="
 
           artifact_dir="${RUN_ROOT}/run-${RUN_ID}"
           mkdir -p "${artifact_dir}"

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -306,18 +306,18 @@ jobs:
           
           # Install .so files if present
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            echo "Installing libvalkeylua.so"
-            sudo mkdir -p /usr/local/lib/valkey/modules/lua
-            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/valkey/modules/lua/
+            echo "Installing libvalkeylua.so to /usr/local/lib/"
+            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
             sudo ldconfig
+            echo "libvalkeylua.so installed and ldconfig updated"
           fi
           
-          # Verify what was installed
+          # Verify installation
           echo "Installed binaries:"
           ls -la /usr/local/bin/valkey-*
           
           echo "Installed libraries:"
-          find /usr/local/lib -name "*.so" 2>/dev/null | grep valkey || echo "No valkey .so files found"
+          ls -la /usr/local/lib/libvalkeylua.so 2>/dev/null || echo "libvalkeylua.so not found"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -238,6 +238,7 @@ jobs:
             valkey-src/src/valkey-server
             valkey-src/src/valkey-cli
             valkey-src/src/valkey-benchmark
+            valkey-src/src/*.so
 
   random-fuzzer:
     name: Random fuzzer run ${{ matrix.run_id }}

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,21 +224,8 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          
-          # Check what .so files were built
-          echo "Checking for shared libraries:"
-          find src -name "*.so" -type f
-          
-          # Install binaries and libraries
           sudo make install PREFIX=/usr/local
-          
-          # Verify installation
-          echo "Verifying valkey-server installation:"
-          which valkey-server
           valkey-server --version
-          
-          echo "Checking installed .so files:"
-          find /usr/local -name "*.so" -type f 2>/dev/null | grep valkey || echo "No valkey .so files found"
 
       - name: Capture resolved SHA
         id: commit
@@ -248,19 +235,14 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          
-          # Copy binaries
           cp /usr/local/bin/valkey-server valkey-binaries/
           cp /usr/local/bin/valkey-cli valkey-binaries/
           cp /usr/local/bin/valkey-benchmark valkey-binaries/
           
-          # Find and copy any installed .so files
-          echo "Looking for installed .so files:"
           if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
-            find /usr/local -name "libvalkeylua.so" -type f -exec cp -v {} valkey-binaries/ \;
+            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
           fi
           
-          echo "Artifact contents:"
           ls -la valkey-binaries/
 
       - name: Upload Valkey binaries
@@ -300,24 +282,12 @@ jobs:
       - name: Install Valkey binaries
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          
-          # Install binaries
           sudo cp "${{ runner.temp }}/valkey-binaries/valkey-"* /usr/local/bin/
           
-          # Install .so files if present
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            echo "Installing libvalkeylua.so to /usr/local/lib/"
             sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
             sudo ldconfig
-            echo "libvalkeylua.so installed and ldconfig updated"
           fi
-          
-          # Verify installation
-          echo "Installed binaries:"
-          ls -la /usr/local/bin/valkey-*
-          
-          echo "Installed libraries:"
-          ls -la /usr/local/lib/libvalkeylua.so 2>/dev/null || echo "libvalkeylua.so not found"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -237,13 +237,7 @@ jobs:
           cp valkey-src/src/valkey-server valkey-binaries/
           cp valkey-src/src/valkey-cli valkey-binaries/
           cp valkey-src/src/valkey-benchmark valkey-binaries/
-          
-          if [ -f valkey-src/src/libvalkeylua.so ]; then
-            cp valkey-src/src/libvalkeylua.so valkey-binaries/
-            echo "✓ libvalkeylua.so found and copied"
-          else
-            echo "✗ libvalkeylua.so NOT found in valkey-src/src/"
-          fi
+          cp valkey-src/src/modules/lua/libvalkeylua.so valkey-binaries/
           
           echo "Packaged binaries:"
           ls -la valkey-binaries/
@@ -292,8 +286,6 @@ jobs:
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
             echo "✓ libvalkeylua.so found in binaries"
-            echo "Setting LD_LIBRARY_PATH for future steps"
-            echo "LD_LIBRARY_PATH=${{ runner.temp }}/valkey-binaries" >> "$GITHUB_ENV"
           else
             echo "✗ libvalkeylua.so NOT found in binaries"
           fi
@@ -312,6 +304,7 @@ jobs:
           RUN_ID: ${{ matrix.run_id }}
           RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
           VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
+          LD_LIBRARY_PATH: ${{ runner.temp }}/valkey-binaries
         run: |
           set +e
           

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,8 +224,7 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          sudo make install PREFIX=/usr/local
-          valkey-server --version
+          src/valkey-server --version
 
       - name: Capture resolved SHA
         id: commit
@@ -235,14 +234,18 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          cp /usr/local/bin/valkey-server valkey-binaries/
-          cp /usr/local/bin/valkey-cli valkey-binaries/
-          cp /usr/local/bin/valkey-benchmark valkey-binaries/
+          cp valkey-src/src/valkey-server valkey-binaries/
+          cp valkey-src/src/valkey-cli valkey-binaries/
+          cp valkey-src/src/valkey-benchmark valkey-binaries/
           
-          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
-            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
+          if [ -f valkey-src/src/libvalkeylua.so ]; then
+            cp valkey-src/src/libvalkeylua.so valkey-binaries/
+            echo "✓ libvalkeylua.so found and copied"
+          else
+            echo "✗ libvalkeylua.so NOT found in valkey-src/src/"
           fi
           
+          echo "Packaged binaries:"
           ls -la valkey-binaries/
 
       - name: Upload Valkey binaries
@@ -281,13 +284,21 @@ jobs:
 
       - name: Install Valkey binaries
         run: |
+          echo "=== Valkey binaries setup ==="
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          sudo cp "${{ runner.temp }}/valkey-binaries/valkey-"* /usr/local/bin/
+          
+          echo "Binaries in temp directory:"
+          ls -la "${{ runner.temp }}/valkey-binaries/"
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
-            sudo ldconfig
+            echo "✓ libvalkeylua.so found in binaries"
+            echo "Setting LD_LIBRARY_PATH for future steps"
+            echo "LD_LIBRARY_PATH=${{ runner.temp }}/valkey-binaries" >> "$GITHUB_ENV"
+          else
+            echo "✗ libvalkeylua.so NOT found in binaries"
           fi
+          
+          echo "=== Setup complete ==="
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -300,9 +311,21 @@ jobs:
         env:
           RUN_ID: ${{ matrix.run_id }}
           RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
-          VALKEY_BINARY: /usr/local/bin/valkey-server
+          VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
         run: |
           set +e
+          
+          echo "=== Environment check ==="
+          echo "VALKEY_BINARY: ${VALKEY_BINARY}"
+          echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+          
+          echo "Testing valkey-server directly:"
+          "${VALKEY_BINARY}" --version || echo "Failed to run valkey-server --version"
+          
+          echo "Checking library dependencies:"
+          ldd "${VALKEY_BINARY}" | grep valkeylua || echo "libvalkeylua.so not in dependencies or not found"
+          
+          echo "=== Starting fuzzer ==="
 
           artifact_dir="${RUN_ROOT}/run-${RUN_ID}"
           mkdir -p "${artifact_dir}"

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,7 +224,8 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          src/valkey-server --version
+          sudo make install PREFIX=/usr/local
+          valkey-server --version
 
       - name: Capture resolved SHA
         id: commit
@@ -234,12 +235,12 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          cp valkey-src/src/valkey-server valkey-binaries/
-          cp valkey-src/src/valkey-cli valkey-binaries/
-          cp valkey-src/src/valkey-benchmark valkey-binaries/
+          cp /usr/local/bin/valkey-server valkey-binaries/
+          cp /usr/local/bin/valkey-cli valkey-binaries/
+          cp /usr/local/bin/valkey-benchmark valkey-binaries/
           
-          if [ -f valkey-src/src/libvalkeylua.so ]; then
-            cp valkey-src/src/libvalkeylua.so valkey-binaries/
+          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
+            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
           fi
           
           ls -la valkey-binaries/
@@ -285,10 +286,7 @@ jobs:
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
             sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
-            echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/usrlocal.conf
             sudo ldconfig
-            echo "Library installed and ldconfig run:"
-            ldconfig -p | grep valkeylua || echo "Warning: libvalkeylua.so not found in ldconfig cache"
           fi
 
       - name: Set up Python

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,7 +224,7 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          valkey-src/src/valkey-server --version
+          src/valkey-server --version
 
       - name: Capture resolved SHA
         id: commit

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -283,7 +283,8 @@ jobs:
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            echo "LD_LIBRARY_PATH=${{ runner.temp }}/valkey-binaries:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
+            sudo ldconfig
           fi
 
       - name: Set up Python

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -222,23 +222,28 @@ jobs:
 
       - name: Build Valkey
         working-directory: valkey-src
-        run: make -j"$(nproc)"
+        run: |
+          make -j"$(nproc)"
+          sudo make install PREFIX=/usr/local
 
       - name: Capture resolved SHA
         id: commit
         working-directory: valkey-src
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Package installed binaries
+        run: |
+          mkdir -p valkey-binaries
+          cp /usr/local/bin/valkey-server valkey-binaries/
+          cp /usr/local/bin/valkey-cli valkey-binaries/
+          cp /usr/local/bin/valkey-benchmark valkey-binaries/
+
       - name: Upload Valkey binaries
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: valkey-pr-binaries
           if-no-files-found: error
-          path: |
-            valkey-src/src/valkey-server
-            valkey-src/src/valkey-cli
-            valkey-src/src/valkey-benchmark
-            valkey-src/src/*.so
+          path: valkey-binaries/
 
   random-fuzzer:
     name: Random fuzzer run ${{ matrix.run_id }}
@@ -267,8 +272,10 @@ jobs:
           name: valkey-pr-binaries
           path: ${{ runner.temp }}/valkey-binaries
 
-      - name: Restore executable bits
-        run: chmod +x "${{ runner.temp }}/valkey-binaries/"*
+      - name: Install Valkey binaries
+        run: |
+          chmod +x "${{ runner.temp }}/valkey-binaries/"*
+          sudo cp "${{ runner.temp }}/valkey-binaries/"* /usr/local/bin/
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -281,7 +288,7 @@ jobs:
         env:
           RUN_ID: ${{ matrix.run_id }}
           RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
-          VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
+          VALKEY_BINARY: /usr/local/bin/valkey-server
         run: |
           set +e
 

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,12 +224,30 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
+          
+          # Check what .so files were built
+          echo "Checking for shared libraries:"
+          ls -la src/*.so 2>/dev/null || echo "No .so files found in src/"
+          
+          # Install binaries
           sudo make install PREFIX=/usr/local
-          # Copy shared libraries to system library path
+          
+          # Explicitly copy any .so files to system library path
           if ls src/*.so 1> /dev/null 2>&1; then
-            sudo cp src/*.so /usr/local/lib/
+            echo "Installing shared libraries to /usr/local/lib/"
+            sudo cp -v src/*.so /usr/local/lib/
             sudo ldconfig
+            echo "Shared libraries installed and ldconfig updated"
+          else
+            echo "No shared libraries to install"
           fi
+          
+          # Verify installation
+          echo "Verifying valkey-server installation:"
+          which valkey-server
+          valkey-server --version
+          echo "Checking library dependencies:"
+          ldd /usr/local/bin/valkey-server | grep -i lua || echo "No lua library dependency found"
 
       - name: Capture resolved SHA
         id: commit
@@ -281,6 +299,16 @@ jobs:
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
           sudo cp "${{ runner.temp }}/valkey-binaries/"* /usr/local/bin/
+          
+          # Verify what was installed
+          echo "Installed binaries:"
+          ls -la /usr/local/bin/valkey-*
+          
+          echo "Checking library dependencies:"
+          ldd /usr/local/bin/valkey-server | grep -i lua || echo "No lua library dependency found"
+          
+          echo "Checking /usr/local/lib/ for .so files:"
+          ls -la /usr/local/lib/*.so 2>/dev/null || echo "No .so files in /usr/local/lib/"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -224,8 +224,7 @@ jobs:
         working-directory: valkey-src
         run: |
           make -j"$(nproc)"
-          sudo make install PREFIX=/usr/local
-          valkey-server --version
+          valkey-src/src/valkey-server --version
 
       - name: Capture resolved SHA
         id: commit
@@ -235,12 +234,12 @@ jobs:
       - name: Package installed binaries
         run: |
           mkdir -p valkey-binaries
-          cp /usr/local/bin/valkey-server valkey-binaries/
-          cp /usr/local/bin/valkey-cli valkey-binaries/
-          cp /usr/local/bin/valkey-benchmark valkey-binaries/
+          cp valkey-src/src/valkey-server valkey-binaries/
+          cp valkey-src/src/valkey-cli valkey-binaries/
+          cp valkey-src/src/valkey-benchmark valkey-binaries/
           
-          if find /usr/local -name "libvalkeylua.so" -type f 2>/dev/null; then
-            find /usr/local -name "libvalkeylua.so" -type f -exec cp {} valkey-binaries/ \;
+          if [ -f valkey-src/src/libvalkeylua.so ]; then
+            cp valkey-src/src/libvalkeylua.so valkey-binaries/
           fi
           
           ls -la valkey-binaries/
@@ -282,11 +281,14 @@ jobs:
       - name: Install Valkey binaries
         run: |
           chmod +x "${{ runner.temp }}/valkey-binaries/"*
-          sudo cp "${{ runner.temp }}/valkey-binaries/valkey-"* /usr/local/bin/
+          mkdir -p "$HOME/.local/bin"
+          cp "${{ runner.temp }}/valkey-binaries/valkey-"* "$HOME/.local/bin/"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           
           if [ -f "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" ]; then
-            sudo cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" /usr/local/lib/
-            sudo ldconfig
+            mkdir -p "$HOME/.local/lib"
+            cp "${{ runner.temp }}/valkey-binaries/libvalkeylua.so" "$HOME/.local/lib/"
+            echo "LD_LIBRARY_PATH=$HOME/.local/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
           fi
 
       - name: Set up Python
@@ -300,7 +302,7 @@ jobs:
         env:
           RUN_ID: ${{ matrix.run_id }}
           RUN_ROOT: ${{ runner.temp }}/valkey-pr-fuzzer
-          VALKEY_BINARY: /usr/local/bin/valkey-server
+          VALKEY_BINARY: ${{ runner.temp }}/valkey-binaries/valkey-server
         run: |
           set +e
 

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -225,6 +225,11 @@ jobs:
         run: |
           make -j"$(nproc)"
           sudo make install PREFIX=/usr/local
+          # Copy shared libraries to system library path
+          if ls src/*.so 1> /dev/null 2>&1; then
+            sudo cp src/*.so /usr/local/lib/
+            sudo ldconfig
+          fi
 
       - name: Capture resolved SHA
         id: commit

--- a/README.md
+++ b/README.md
@@ -98,13 +98,39 @@ valkey-fuzzer cluster --dsl examples/simple_failover.yaml --valkey-binary /tmp/v
 
 ### PR-Triggered Fuzzer Runs
 
-This repo now includes a reusable GitHub Actions workflow at `.github/workflows/valkey-pr-fuzzer.yml` that can:
+This repo includes a reusable GitHub Actions workflow at `.github/workflows/valkey-pr-fuzzer.yml` that can:
 
 - build Valkey from a specific ref, including a PR merge ref such as `refs/pull/123/merge`
 - fan out a configurable number of random fuzzer runs, defaulting to `10`
 - upload per-run artifacts with the console log, node logs, and JSON result payload
 - fail the overall workflow if any run fails, while still letting all matrix runs complete
 - treat a run as failed if any operation fails, any chaos injection fails, any post-operation validation wave fails, or the final validation fails
+
+#### Manual Trigger
+
+You can manually trigger the fuzzer workflow from the GitHub Actions UI:
+
+1. Navigate to **Actions** → **Valkey Cluster PR Fuzzer**
+2. Click **Run workflow**
+3. Fill in the required inputs:
+   - `valkey_repository`: Repository containing the Valkey code (e.g., `valkey-io/valkey` or `username/valkey`)
+   - `valkey_ref`: Git ref to test (e.g., `refs/pull/123/merge`, `main`, or a commit SHA)
+   - `pr_number`: (Optional) PR number for summary display
+   - `pr_url`: (Optional) PR URL for summary display
+   - `run_count`: Number of random fuzzer runs (default: 10)
+   - `fuzzer_repository`: (Optional) Override fuzzer repo to use
+   - `fuzzer_ref`: (Optional) Override fuzzer ref to use
+
+Example manual trigger inputs:
+```
+valkey_repository: valkey-io/valkey
+valkey_ref: refs/pull/456/merge
+pr_number: 456
+pr_url: https://github.com/valkey-io/valkey/pull/456
+run_count: 5
+```
+
+#### Label-Triggered Workflow
 
 If you want this to run when a label is applied in the Valkey repo, the Valkey repo needs a small caller workflow. Example:
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This repo includes a reusable GitHub Actions workflow at `.github/workflows/valk
 
 You can manually trigger the fuzzer workflow from the GitHub Actions UI:
 
-1. Navigate to **Actions** → **Valkey Cluster PR Fuzzer**
+1. Navigate to **Actions** -> **Valkey Cluster PR Fuzzer**
 2. Click **Run workflow**
 3. Fill in the required inputs:
    - `valkey_repository`: Repository containing the Valkey code (e.g., `valkey-io/valkey` or `username/valkey`)
@@ -129,6 +129,20 @@ pr_number: 456
 pr_url: https://github.com/valkey-io/valkey/pull/456
 run_count: 5
 ```
+
+Each fuzzer run uploads artifacts containing:
+- `console.log` - Full fuzzer execution output
+- `result.json` - Structured test results
+- `metadata.json` - Run metadata (status, seed, duration, failures)
+- `node-logs/` - Individual Valkey node logs from `/tmp/valkey-fuzzer/logs`
+
+To access these:
+1. Navigate to the workflow run in **Actions**
+2. Scroll to the **Artifacts** section at the bottom
+3. Download `valkey-pr-fuzzer-run-N` for each run
+4. Extract and examine the logs to debug failures
+
+You can also see the full Fuzzer Run and other information in the `Execute Fuzzer Run` job
 
 #### Label-Triggered Workflow
 
@@ -398,7 +412,7 @@ The architecture is designed to support expansion in multiple dimensions:
 
 ## Daily Test Runs
 - We run a randomly generated scenario every 4 hours and the results are listed here: https://github.com/valkey-io/valkey-fuzzer/actions/workflows/fuzzer-run.yml
-- Each scheduled run uploads a `fuzzer-run-artifacts-*` bundle containing the structured `results.json`, the exported scenario DSL, and the collected node/test logs from `/tmp/valkey-fuzzer/logs`.
+- Each scheduled run uploads a `fuzzer-run-artifacts-*` bundle containing the structured `results.json`, the exported scenario DSL, and the collected node/test logs from `/tmp/valkey-fuzzer/logs`
 - These results can be analyzed to find potential bugs in Valkey
 
 ## License


### PR DESCRIPTION
This PR fixes the `libvalkeylua.so: cannot open shared object file` error when testing Valkey PRs that build Lua as a shared library.