### PR TITLE
Accept PR Link input to simplify workflow_dispatch usage

### DIFF
--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -774,11 +774,25 @@ jobs:
             const body = fs.readFileSync('pr-comment.md', 'utf8');
             const marker = '<!-- valkey-cluster-fuzzer-results -->';
             const issue_number = Number('${{ needs.resolve-inputs.outputs.pr_number }}');
-            const {owner, repo} = context.repo;
+            const valkey_repository = '${{ needs.resolve-inputs.outputs.valkey_repository }}';
+            const [target_owner, target_repo] = valkey_repository.split('/');
+            const {owner: workflow_owner, repo: workflow_repo} = context.repo;
+
+            // The GITHUB_TOKEN only has permissions on the workflow repo.
+            // When the PR lives in a different repository (e.g. valkey-io/valkey
+            // while the workflow runs in valkey-io/valkey-fuzzer), skip commenting
+            // because the token cannot access the target repo.
+            if (target_owner !== workflow_owner || target_repo !== workflow_repo) {
+              core.info(
+                `Skipping PR comment: PR is in ${valkey_repository} but workflow ` +
+                `is running in ${workflow_owner}/${workflow_repo}`
+              );
+              return;
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
+              owner: target_owner,
+              repo: target_repo,
               issue_number,
               per_page: 100,
             });
@@ -789,15 +803,15 @@ jobs:
 
             if (existing) {
               await github.rest.issues.updateComment({
-                owner,
-                repo,
+                owner: target_owner,
+                repo: target_repo,
                 comment_id: existing.id,
                 body,
               });
             } else {
               await github.rest.issues.createComment({
-                owner,
-                repo,
+                owner: target_owner,
+                repo: target_repo,
                 issue_number,
                 body,
               });

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -169,11 +169,34 @@ jobs:
                   )
               parsed_repo = match.group(1)
               parsed_number = match.group(2)
+              parsed_ref = f"refs/pull/{parsed_number}/merge"
 
-              # PR link values are defaults; explicit inputs override them
-              valkey_repository = valkey_repository or parsed_repo
-              valkey_ref = valkey_ref or f"refs/pull/{parsed_number}/merge"
-              pr_number = pr_number or parsed_number
+              # Reject explicit overrides that contradict the PR link so we
+              # never mix metadata from different PRs (e.g. building one ref
+              # but commenting on a different PR number).
+              conflicts = []
+              if valkey_repository and valkey_repository != parsed_repo:
+                  conflicts.append(
+                      f"valkey_repository={valkey_repository!r} vs pr_link repo {parsed_repo!r}"
+                  )
+              if valkey_ref and valkey_ref != parsed_ref:
+                  conflicts.append(
+                      f"valkey_ref={valkey_ref!r} vs pr_link ref {parsed_ref!r}"
+                  )
+              if pr_number and pr_number != parsed_number:
+                  conflicts.append(
+                      f"pr_number={pr_number!r} vs pr_link number {parsed_number!r}"
+                  )
+              if conflicts:
+                  raise SystemExit(
+                      "Conflicting inputs: "
+                      + "; ".join(conflicts)
+                      + ". Remove the conflicting overrides or adjust pr_link."
+                  )
+
+              valkey_repository = parsed_repo
+              valkey_ref = parsed_ref
+              pr_number = parsed_number
               pr_url = pr_url or pr_link
           else:
               # No pr_link provided — fall back to explicit inputs

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -96,7 +96,11 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: valkey-pr-fuzzer-${{ inputs.pr_link || inputs.valkey_repository || 'pending' }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref || inputs.pr_link || 'pending' }}
+  # pr_link is authoritative for dispatch; for workflow_call the caller
+  # provides valkey_repository + valkey_ref directly.  Using the raw
+  # inputs here is acceptable because resolve-inputs will fail fast on
+  # any mismatch, so only consistent input sets reach the expensive jobs.
+  group: valkey-pr-fuzzer-${{ inputs.pr_link || format('{0}-{1}', inputs.valkey_repository || 'valkey-io/valkey', inputs.valkey_ref || 'pending') }}
   cancel-in-progress: false
 
 jobs:
@@ -123,7 +127,6 @@ jobs:
         run: |
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import os
-          import re
 
           event_name = os.environ["EVENT_NAME"]
           pr_link = os.environ.get("INPUT_PR_LINK", "").strip()
@@ -132,20 +135,38 @@ jobs:
           pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
           pr_url = os.environ.get("INPUT_PR_URL", "").strip()
 
+          from urllib.parse import urlparse
+
+          def parse_pr_url(url):
+              """Extract (owner/repo, number) from a GitHub PR URL.
+
+              Accepts common variants such as:
+                https://github.com/owner/repo/pull/123
+                https://github.com/owner/repo/pull/123/files
+                https://github.com/owner/repo/pull/123/commits
+                https://github.com/owner/repo/pull/123?w=1
+                https://github.com/owner/repo/pull/123#discussion_r...
+              """
+              parsed = urlparse(url)
+              if parsed.hostname != "github.com":
+                  return None
+              parts = parsed.path.strip("/").split("/")
+              # Expect at least owner/repo/pull/number
+              if len(parts) < 4 or parts[2] != "pull" or not parts[3].isdigit():
+                  return None
+              return f"{parts[0]}/{parts[1]}", parts[3]
+
           # Recover a full PR URL pasted into pr_number before any
           # validation so that the extracted values are available to the
           # pr_link / valkey_ref branches below.
           if pr_number and not pr_number.isdigit():
-              url_match = re.match(
-                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_number
-              )
-              if url_match:
-                  # Treat the URL as if it were pr_link
+              parsed = parse_pr_url(pr_number)
+              if parsed:
+                  # Treat the URL as if it were pr_link — pr_link is
+                  # authoritative, so it overwrites the target fields.
                   pr_link = pr_link or pr_number
-                  valkey_repository = valkey_repository or url_match.group(1)
-                  valkey_ref = valkey_ref or f"refs/pull/{url_match.group(2)}/merge"
                   pr_url = pr_url or pr_number
-                  pr_number = url_match.group(2)
+                  pr_number = parsed[1]
               else:
                   raise SystemExit(
                       f"inputs.pr_number must be a numeric PR number, got {pr_number!r}. "
@@ -158,22 +179,17 @@ jobs:
               if not valkey_ref:
                   raise SystemExit("workflow_call requires inputs.valkey_ref")
           elif pr_link:
-              # Parse the PR URL: https://github.com/{owner}/{repo}/pull/{number}
-              match = re.match(
-                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_link
-              )
-              if not match:
+              parsed = parse_pr_url(pr_link)
+              if not parsed:
                   raise SystemExit(
                       f"Invalid PR link format: {pr_link!r}. "
                       "Expected: https://github.com/OWNER/REPO/pull/NUMBER"
                   )
-              parsed_repo = match.group(1)
-              parsed_number = match.group(2)
+              parsed_repo, parsed_number = parsed
               parsed_ref = f"refs/pull/{parsed_number}/merge"
 
-              # Reject explicit overrides that contradict the PR link so we
-              # never mix metadata from different PRs (e.g. building one ref
-              # but commenting on a different PR number).
+              # pr_link is authoritative: reject any explicit overrides that
+              # disagree so we never mix metadata from different PRs.
               conflicts = []
               if valkey_repository and valkey_repository != parsed_repo:
                   conflicts.append(
@@ -194,6 +210,7 @@ jobs:
                       + ". Remove the conflicting overrides or adjust pr_link."
                   )
 
+              # Overwrite target fields from the link (authoritative).
               valkey_repository = parsed_repo
               valkey_ref = parsed_ref
               pr_number = parsed_number

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -50,32 +50,32 @@ on:
         type: string
         default: ""
       fuzzer_repository:
-        description: Repository containing the fuzzer workflow and code to check out
+        description: "Advanced: alternate fuzzer repository to check out for manual testing. Defaults to the current repository/commit."
         required: false
         type: string
         default: ""
       fuzzer_ref:
-        description: Branch, tag, or commit SHA of the fuzzer repo to check out
+        description: "Advanced: alternate fuzzer branch, tag, or commit SHA to check out for manual testing. Defaults to the current commit."
         required: false
         type: string
         default: ""
       valkey_repository:
-        description: "Repository containing the Valkey commit to test (auto-filled from pr_link)"
+        description: "Repository containing the Valkey commit to test when not using pr_link"
         required: false
         type: string
         default: ""
       valkey_ref:
-        description: "Ref to build and test (auto-filled from pr_link, e.g. refs/pull/123/merge)"
+        description: "Ref to build and test when not using pr_link (e.g. refs/pull/123/merge)"
         required: false
         type: string
         default: ""
       pr_number:
-        description: "Pull request number (auto-filled from pr_link)"
+        description: "Optional PR number for summary/comment metadata when not using pr_link"
         required: false
         type: string
         default: ""
       pr_url:
-        description: "Pull request URL (auto-filled from pr_link)"
+        description: "Optional PR URL for summary/comment metadata when not using pr_link"
         required: false
         type: string
         default: ""

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -96,10 +96,11 @@ permissions:
   pull-requests: write
 
 concurrency:
-  # pr_link is authoritative for dispatch; for workflow_call the caller
-  # provides valkey_repository + valkey_ref directly.  Using the raw
-  # inputs here is acceptable because resolve-inputs will fail fast on
-  # any mismatch, so only consistent input sets reach the expensive jobs.
+  # Lightweight guard keyed off the resolved target. The resolve-inputs
+  # job is cheap (no build); once it finishes, the expensive build and
+  # fuzz jobs carry their own concurrency group derived from the
+  # canonical repository + ref so that different URL variants for the
+  # same PR always serialize correctly.
   group: valkey-pr-fuzzer-${{ inputs.pr_link || format('{0}-{1}', inputs.valkey_repository || 'valkey-io/valkey', inputs.valkey_ref || 'pending') }}
   cancel-in-progress: false
 
@@ -114,6 +115,7 @@ jobs:
       valkey_ref: ${{ steps.resolve.outputs.valkey_ref }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       pr_url: ${{ steps.resolve.outputs.pr_url }}
+      concurrency_key: ${{ steps.resolve.outputs.concurrency_key }}
     steps:
       - name: Resolve PR link and inputs
         id: resolve
@@ -127,6 +129,7 @@ jobs:
         run: |
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import os
+          from urllib.parse import urlparse
 
           event_name = os.environ["EVENT_NAME"]
           pr_link = os.environ.get("INPUT_PR_LINK", "").strip()
@@ -134,8 +137,6 @@ jobs:
           valkey_ref = os.environ.get("INPUT_VALKEY_REF", "").strip()
           pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
           pr_url = os.environ.get("INPUT_PR_URL", "").strip()
-
-          from urllib.parse import urlparse
 
           def parse_pr_url(url):
               """Extract (owner/repo, number) from a GitHub PR URL.
@@ -227,6 +228,9 @@ jobs:
           print(f"valkey_ref={valkey_ref}")
           print(f"pr_number={pr_number}")
           print(f"pr_url={pr_url}")
+          # Canonical concurrency key derived from the resolved target so
+          # that different URL variants for the same PR always serialize.
+          print(f"concurrency_key=valkey-pr-fuzzer-{valkey_repository}-{valkey_ref}")
           PY
 
   prepare-matrix:
@@ -341,6 +345,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: ${{ needs.resolve-inputs.outputs.concurrency_key }}
+      cancel-in-progress: false
     outputs:
       resolved_sha: ${{ steps.commit.outputs.sha }}
     steps:

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -793,14 +793,17 @@ jobs:
         if: ${{ needs.resolve-inputs.outputs.pr_number != '' }}
         continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ needs.resolve-inputs.outputs.pr_number }}
+          VALKEY_REPOSITORY: ${{ needs.resolve-inputs.outputs.valkey_repository }}
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const body = fs.readFileSync('pr-comment.md', 'utf8');
             const marker = '<!-- valkey-cluster-fuzzer-results -->';
-            const issue_number = Number('${{ needs.resolve-inputs.outputs.pr_number }}');
-            const valkey_repository = '${{ needs.resolve-inputs.outputs.valkey_repository }}';
+            const issue_number = Number(process.env.PR_NUMBER);
+            const valkey_repository = process.env.VALKEY_REPOSITORY;
             const [target_owner, target_repo] = valkey_repository.split('/');
             const {owner: workflow_owner, repo: workflow_repo} = context.repo;
 

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -414,6 +414,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: ${{ needs.resolve-inputs.outputs.concurrency_key }}-run-${{ matrix.run_id }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -828,7 +831,6 @@ jobs:
 
       - name: Comment on PR with fuzzer results
         if: ${{ needs.resolve-inputs.outputs.pr_number != '' }}
-        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_NUMBER: ${{ needs.resolve-inputs.outputs.pr_number }}

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -765,6 +765,7 @@ jobs:
 
       - name: Comment on PR with fuzzer results
         if: ${{ needs.resolve-inputs.outputs.pr_number != '' }}
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ github.token }}
@@ -803,5 +804,5 @@ jobs:
             }
 
       - name: Mark summary job as failed when any run fails
-        if: steps.summary.outputs.overall_failed == 'true'
+        if: always() && steps.summary.outputs.overall_failed == 'true'
         run: exit 1

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -163,6 +163,23 @@ jobs:
                       "Either pr_link or valkey_ref must be provided"
                   )
 
+          # Guard against a URL being pasted into pr_number by mistake
+          if pr_number and not pr_number.isdigit():
+              url_match = re.match(
+                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_number
+              )
+              if url_match:
+                  # Recover: treat it as if it were pr_link
+                  valkey_repository = valkey_repository or url_match.group(1)
+                  valkey_ref = valkey_ref or f"refs/pull/{url_match.group(2)}/merge"
+                  pr_url = pr_url or pr_number
+                  pr_number = url_match.group(2)
+              else:
+                  raise SystemExit(
+                      f"inputs.pr_number must be a numeric PR number, got {pr_number!r}. "
+                      "Use the pr_link input for full URLs."
+                  )
+
           print(f"valkey_repository={valkey_repository}")
           print(f"valkey_ref={valkey_ref}")
           print(f"pr_number={pr_number}")

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -132,6 +132,26 @@ jobs:
           pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
           pr_url = os.environ.get("INPUT_PR_URL", "").strip()
 
+          # Recover a full PR URL pasted into pr_number before any
+          # validation so that the extracted values are available to the
+          # pr_link / valkey_ref branches below.
+          if pr_number and not pr_number.isdigit():
+              url_match = re.match(
+                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_number
+              )
+              if url_match:
+                  # Treat the URL as if it were pr_link
+                  pr_link = pr_link or pr_number
+                  valkey_repository = valkey_repository or url_match.group(1)
+                  valkey_ref = valkey_ref or f"refs/pull/{url_match.group(2)}/merge"
+                  pr_url = pr_url or pr_number
+                  pr_number = url_match.group(2)
+              else:
+                  raise SystemExit(
+                      f"inputs.pr_number must be a numeric PR number, got {pr_number!r}. "
+                      "Use the pr_link input for full URLs."
+                  )
+
           if event_name == "workflow_call":
               # workflow_call does not have pr_link; pass inputs through as-is
               valkey_repository = valkey_repository or "valkey-io/valkey"
@@ -161,23 +181,6 @@ jobs:
               if not valkey_ref:
                   raise SystemExit(
                       "Either pr_link or valkey_ref must be provided"
-                  )
-
-          # Guard against a URL being pasted into pr_number by mistake
-          if pr_number and not pr_number.isdigit():
-              url_match = re.match(
-                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_number
-              )
-              if url_match:
-                  # Recover: treat it as if it were pr_link
-                  valkey_repository = valkey_repository or url_match.group(1)
-                  valkey_ref = valkey_ref or f"refs/pull/{url_match.group(2)}/merge"
-                  pr_url = pr_url or pr_number
-                  pr_number = url_match.group(2)
-              else:
-                  raise SystemExit(
-                      f"inputs.pr_number must be a numeric PR number, got {pr_number!r}. "
-                      "Use the pr_link input for full URLs."
                   )
 
           print(f"valkey_repository={valkey_repository}")

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -98,7 +98,7 @@ permissions:
 concurrency:
   # Lightweight guard keyed off the resolved target. The resolve-inputs
   # job is cheap (no build); once it finishes, the expensive build and
-  # fuzz jobs carry their own concurrency group derived from the
+  # final summarize path carry their own concurrency group derived from the
   # canonical repository + ref so that different URL variants for the
   # same PR always serialize correctly.
   group: valkey-pr-fuzzer-${{ inputs.pr_link || format('{0}-{1}', inputs.valkey_repository || 'valkey-io/valkey', inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || inputs.valkey_ref || 'pending') }}
@@ -166,7 +166,6 @@ jobs:
                   # Treat the URL as if it were pr_link — pr_link is
                   # authoritative, so it overwrites the target fields.
                   pr_link = pr_link or pr_number
-                  pr_url = pr_url or pr_number
                   pr_number = parsed[1]
               else:
                   raise SystemExit(
@@ -215,7 +214,6 @@ jobs:
               valkey_repository = parsed_repo
               valkey_ref = parsed_ref
               pr_number = parsed_number
-              pr_url = pr_url or pr_link
           else:
               # No pr_link provided — fall back to explicit inputs
               valkey_repository = valkey_repository or "valkey-io/valkey"
@@ -223,6 +221,12 @@ jobs:
                   raise SystemExit(
                       "Either pr_link or valkey_ref must be provided"
                   )
+
+          # Always publish a canonical PR URL once the repository and PR
+          # number are known so summaries and comments cannot drift from
+          # the actual target.
+          if pr_number:
+              pr_url = f"https://github.com/{valkey_repository}/pull/{pr_number}"
 
           print(f"valkey_repository={valkey_repository}")
           print(f"valkey_ref={valkey_ref}")
@@ -593,6 +597,9 @@ jobs:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ needs.resolve-inputs.outputs.concurrency_key }}
+      cancel-in-progress: false
     steps:
       - name: Download run artifacts
         continue-on-error: true

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -101,7 +101,7 @@ concurrency:
   # fuzz jobs carry their own concurrency group derived from the
   # canonical repository + ref so that different URL variants for the
   # same PR always serialize correctly.
-  group: valkey-pr-fuzzer-${{ inputs.pr_link || format('{0}-{1}', inputs.valkey_repository || 'valkey-io/valkey', inputs.valkey_ref || 'pending') }}
+  group: valkey-pr-fuzzer-${{ inputs.pr_link || format('{0}-{1}', inputs.valkey_repository || 'valkey-io/valkey', inputs.pr_number != '' && format('pr-{0}', inputs.pr_number) || inputs.valkey_ref || 'pending') }}
   cancel-in-progress: false
 
 jobs:
@@ -230,7 +230,13 @@ jobs:
           print(f"pr_url={pr_url}")
           # Canonical concurrency key derived from the resolved target so
           # that different URL variants for the same PR always serialize.
-          print(f"concurrency_key=valkey-pr-fuzzer-{valkey_repository}-{valkey_ref}")
+          # When pr_number is set, key off repository + pr_number so that
+          # runs targeting the same PR (even with different refs) serialize
+          # and don't overwrite each other's PR comment.
+          if pr_number:
+              print(f"concurrency_key=valkey-pr-fuzzer-{valkey_repository}-pr-{pr_number}")
+          else:
+              print(f"concurrency_key=valkey-pr-fuzzer-{valkey_repository}-{valkey_ref}")
           PY
 
   prepare-matrix:

--- a/.github/workflows/valkey-pr-fuzzer.yml
+++ b/.github/workflows/valkey-pr-fuzzer.yml
@@ -44,6 +44,11 @@ on:
         default: 10
   workflow_dispatch:
     inputs:
+      pr_link:
+        description: "GitHub PR URL (e.g. https://github.com/valkey-io/valkey/pull/123). Fills in repository, ref, pr_number, and pr_url automatically."
+        required: false
+        type: string
+        default: ""
       fuzzer_repository:
         description: Repository containing the fuzzer workflow and code to check out
         required: false
@@ -55,21 +60,22 @@ on:
         type: string
         default: ""
       valkey_repository:
-        description: Repository containing the Valkey commit to test
+        description: "Repository containing the Valkey commit to test (auto-filled from pr_link)"
         required: false
         type: string
-        default: valkey-io/valkey
+        default: ""
       valkey_ref:
-        description: Ref to build and test, for example refs/pull/123/merge
-        required: true
+        description: "Ref to build and test (auto-filled from pr_link, e.g. refs/pull/123/merge)"
+        required: false
         type: string
+        default: ""
       pr_number:
-        description: Pull request number, used only for summaries
+        description: "Pull request number (auto-filled from pr_link)"
         required: false
         type: string
         default: ""
       pr_url:
-        description: Pull request URL, used only for summaries
+        description: "Pull request URL (auto-filled from pr_link)"
         required: false
         type: string
         default: ""
@@ -90,11 +96,82 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: valkey-pr-fuzzer-${{ inputs.valkey_repository }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref }}
+  group: valkey-pr-fuzzer-${{ inputs.pr_link || inputs.valkey_repository || 'pending' }}-${{ inputs.pr_number != '' && inputs.pr_number || inputs.valkey_ref || inputs.pr_link || 'pending' }}
   cancel-in-progress: false
 
 jobs:
+  resolve-inputs:
+    name: Resolve inputs
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      valkey_repository: ${{ steps.resolve.outputs.valkey_repository }}
+      valkey_ref: ${{ steps.resolve.outputs.valkey_ref }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      pr_url: ${{ steps.resolve.outputs.pr_url }}
+    steps:
+      - name: Resolve PR link and inputs
+        id: resolve
+        env:
+          INPUT_PR_LINK: ${{ inputs.pr_link }}
+          INPUT_VALKEY_REPOSITORY: ${{ inputs.valkey_repository }}
+          INPUT_VALKEY_REF: ${{ inputs.valkey_ref }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_PR_URL: ${{ inputs.pr_url }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+          import re
+
+          event_name = os.environ["EVENT_NAME"]
+          pr_link = os.environ.get("INPUT_PR_LINK", "").strip()
+          valkey_repository = os.environ.get("INPUT_VALKEY_REPOSITORY", "").strip()
+          valkey_ref = os.environ.get("INPUT_VALKEY_REF", "").strip()
+          pr_number = os.environ.get("INPUT_PR_NUMBER", "").strip()
+          pr_url = os.environ.get("INPUT_PR_URL", "").strip()
+
+          if event_name == "workflow_call":
+              # workflow_call does not have pr_link; pass inputs through as-is
+              valkey_repository = valkey_repository or "valkey-io/valkey"
+              if not valkey_ref:
+                  raise SystemExit("workflow_call requires inputs.valkey_ref")
+          elif pr_link:
+              # Parse the PR URL: https://github.com/{owner}/{repo}/pull/{number}
+              match = re.match(
+                  r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)/?$", pr_link
+              )
+              if not match:
+                  raise SystemExit(
+                      f"Invalid PR link format: {pr_link!r}. "
+                      "Expected: https://github.com/OWNER/REPO/pull/NUMBER"
+                  )
+              parsed_repo = match.group(1)
+              parsed_number = match.group(2)
+
+              # PR link values are defaults; explicit inputs override them
+              valkey_repository = valkey_repository or parsed_repo
+              valkey_ref = valkey_ref or f"refs/pull/{parsed_number}/merge"
+              pr_number = pr_number or parsed_number
+              pr_url = pr_url or pr_link
+          else:
+              # No pr_link provided — fall back to explicit inputs
+              valkey_repository = valkey_repository or "valkey-io/valkey"
+              if not valkey_ref:
+                  raise SystemExit(
+                      "Either pr_link or valkey_ref must be provided"
+                  )
+
+          print(f"valkey_repository={valkey_repository}")
+          print(f"valkey_ref={valkey_ref}")
+          print(f"pr_number={pr_number}")
+          print(f"pr_url={pr_url}")
+          PY
+
   prepare-matrix:
+    needs:
+      - resolve-inputs
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -198,6 +275,7 @@ jobs:
   build-valkey:
     name: Build Valkey
     needs:
+      - resolve-inputs
       - prepare-matrix
     permissions:
       contents: read
@@ -209,8 +287,8 @@ jobs:
       - name: Checkout Valkey
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          repository: ${{ inputs.valkey_repository }}
-          ref: ${{ inputs.valkey_ref }}
+          repository: ${{ needs.resolve-inputs.outputs.valkey_repository }}
+          ref: ${{ needs.resolve-inputs.outputs.valkey_ref }}
           fetch-depth: 1
           path: valkey-src
           persist-credentials: false
@@ -252,6 +330,7 @@ jobs:
   random-fuzzer:
     name: Random fuzzer run ${{ matrix.run_id }}
     needs:
+      - resolve-inputs
       - prepare-matrix
       - build-valkey
     permissions:
@@ -432,6 +511,7 @@ jobs:
     name: Summarize cluster fuzzer results
     if: ${{ always() }}
     needs:
+      - resolve-inputs
       - prepare-matrix
       - build-valkey
       - random-fuzzer
@@ -457,10 +537,10 @@ jobs:
           FUZZER_REPOSITORY: ${{ needs.prepare-matrix.outputs.fuzzer_repository }}
           FUZZER_REF: ${{ needs.prepare-matrix.outputs.fuzzer_ref }}
           RUN_COUNT: ${{ inputs.run_count }}
-          VALKEY_REPOSITORY: ${{ inputs.valkey_repository }}
-          VALKEY_REF: ${{ inputs.valkey_ref }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          PR_URL: ${{ inputs.pr_url }}
+          VALKEY_REPOSITORY: ${{ needs.resolve-inputs.outputs.valkey_repository }}
+          VALKEY_REF: ${{ needs.resolve-inputs.outputs.valkey_ref }}
+          PR_NUMBER: ${{ needs.resolve-inputs.outputs.pr_number }}
+          PR_URL: ${{ needs.resolve-inputs.outputs.pr_url }}
           LABEL_NAME: ${{ inputs.label_name }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -667,7 +747,7 @@ jobs:
           PY
 
       - name: Comment on PR with fuzzer results
-        if: ${{ inputs.pr_number != '' }}
+        if: ${{ needs.resolve-inputs.outputs.pr_number != '' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ github.token }}
@@ -675,7 +755,7 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('pr-comment.md', 'utf8');
             const marker = '<!-- valkey-cluster-fuzzer-results -->';
-            const issue_number = Number('${{ inputs.pr_number }}');
+            const issue_number = Number('${{ needs.resolve-inputs.outputs.pr_number }}');
             const {owner, repo} = context.repo;
 
             const comments = await github.paginate(github.rest.issues.listComments, {


### PR DESCRIPTION
## Summary

Add a `pr_link` input to `workflow_dispatch` that accepts a GitHub PR URL (e.g. `https://github.com/valkey-io/valkey/pull/123`) and automatically derives `valkey_repository`, `valkey_ref`, `pr_number`, and `pr_url` from it.

## Before

To run the fuzzer against a PR via workflow_dispatch, you had to fill in:
- `valkey_repository` (e.g. `valkey-io/valkey`)
- `valkey_ref` (e.g. `refs/pull/123/merge`)
- `pr_number` (e.g. `123`)
- `pr_url` (e.g. `https://github.com/valkey-io/valkey/pull/123`)

## After

Just paste the PR link into `pr_link` and leave the rest at defaults. Everything is derived automatically.

## Details

- New `resolve-inputs` job parses the PR URL and outputs resolved values for downstream jobs
- All downstream jobs (`build-valkey`, `random-fuzzer`, `summarize`) read from `needs.resolve-inputs.outputs.*`
- The existing individual inputs still work as overrides
- `workflow_call` is unaffected (it doesn't have `pr_link` and the resolve job passes its inputs through as-is)
- Concurrency group updated to include `pr_link` so concurrent runs for different PRs don't collide