### PR TITLE
Fixed issues with False Positive Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The current implementation focuses on:
 
 ### Supported Configurations
 - **Cluster Sizes**: 3-16 shards
-- **Replication**: 0-2 replicas per shard
+- **Replication**: 0-5 replicas per shard
 - **Deployment**: Single metal instance with multiple processes
 
 ### Validation Capabilities

--- a/docs/fuzzer-engine-design.md
+++ b/docs/fuzzer-engine-design.md
@@ -168,7 +168,7 @@ def generate_random_scenario(self, seed: Optional[int] = None) -> Scenario:
     
     # Generate cluster configuration
     shard_count = rng.randint(3, 16)
-    replica_count = rng.randint(0, 2)
+    replica_count = rng.randint(0, 5)
     cluster_config = self._generate_cluster_config(shard_count, replica_count)
     
     # Generate operations sequence

--- a/src/fuzzer_engine/dsl_utils.py
+++ b/src/fuzzer_engine/dsl_utils.py
@@ -232,8 +232,8 @@ class DSLValidator:
         
         if 'replicas_per_shard' in cluster_dict:
             replicas = cluster_dict['replicas_per_shard']
-            if not isinstance(replicas, int) or not (0 <= replicas <= 2):
-                errors.append(f"cluster.replicas_per_shard: Must be an integer between 0 and 2, got {replicas}")
+            if not isinstance(replicas, int) or not (0 <= replicas <= 5):
+                errors.append(f"cluster.replicas_per_shard: Must be an integer between 0 and 5, got {replicas}")
         
         return errors
     

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -392,7 +392,7 @@ class FuzzerEngine(IFuzzerEngine):
                 if node.node_id == target_node_id:
                     node_address = f"{node.host}:{node.port}"
                     state_validator.register_killed_node(node_address, target_role, node.shard_id)
-                    logger.info(
+                    logger.debug(
                         f"Registered killed node for validation: {node_address} "
                         f"(role: {target_role}, shard: {node.shard_id})"
                     )

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -159,6 +159,13 @@ class FuzzerEngine(IFuzzerEngine):
                 logger.info(f"Adjusted min_replicas_per_shard to {expected_replicas_per_shard} to match cluster configuration")
 
             state_validator = StateValidator(validation_config)
+
+            # Set nodes per shard for full-shard-kill detection
+            nodes_per_shard_count = 1 + scenario.cluster_config.replicas_per_shard  # primary + replicas
+            state_validator.set_nodes_per_shard({
+                shard_id: nodes_per_shard_count
+                for shard_id in range(scenario.cluster_config.num_shards)
+            })
             
             # Write test data for data consistency validation
             if validation_config.check_data_consistency:

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -5,7 +5,7 @@ import time
 import logging
 import threading
 from typing import Dict, Optional
-from ..models import Operation, OperationType, ClusterStatus, ClusterConnection
+from ..models import Operation, OperationType, ClusterStatus, ClusterConnection, ChaosResult
 from ..interfaces import IOperationOrchestrator
 from ..cluster_orchestrator.orchestrator import ClusterManager
 from ..utils.valkey_utils import valkey_client, query_cluster_nodes
@@ -27,7 +27,7 @@ class OperationOrchestrator(IOperationOrchestrator):
         """Set or update cluster connection"""
         self.cluster_connection = cluster_connection
     
-    def execute_operation(self, operation: Operation, log_buffer=None) -> bool:
+    def execute_operation(self, operation: Operation, log_buffer=None, chaos_events=None) -> bool:
         """Execute a single cluster operation"""
         log = log_buffer if log_buffer else logging
         
@@ -50,7 +50,7 @@ class OperationOrchestrator(IOperationOrchestrator):
             # Execute based on operation type
             success = False
             if operation.type == OperationType.FAILOVER:
-                success = self._execute_failover(operation, log)
+                success = self._execute_failover(operation, log, chaos_events=chaos_events)
             else:
                 log.error(f"Unsupported operation type: {operation.type}")
                 return False
@@ -74,7 +74,7 @@ class OperationOrchestrator(IOperationOrchestrator):
                     del self.active_operations[operation_id]
             return False
     
-    def _execute_failover(self, operation: Operation, log=None) -> bool:
+    def _execute_failover(self, operation: Operation, log=None, chaos_events=None) -> bool:
         """Execute failover operation"""
         if log is None:
             log = logging
@@ -169,7 +169,7 @@ class OperationOrchestrator(IOperationOrchestrator):
             
             if not replica:
                 log.error(f"Cannot execute failover: No alive replicas found for primary {operation.target_node}")
-                return False
+                return self._all_replicas_killed_by_chaos(replica_nodes, chaos_events, log)
             
             log.info(f"Selected alive replica at port {replica['port']} for failover")
             log.info(f"Executing CLUSTER FAILOVER from replica at port {replica['port']}")
@@ -190,6 +190,55 @@ class OperationOrchestrator(IOperationOrchestrator):
         except Exception as e:
             log.error(f"Failover execution failed: {e}")
             return False
+
+    def _all_replicas_killed_by_chaos(self, replica_nodes, chaos_events, log) -> bool:
+        """Check if every replica of the shard was killed by chaos injection.
+        
+        Returns True only if ALL dead replicas can be accounted for by a matching
+        chaos event. If any replica is dead for an unexplained reason, returns False.
+        
+        Uses port-based matching because chaos events use logical node IDs (e.g. "node-0")
+        while replica_nodes from CLUSTER NODES use Valkey cluster hex IDs.
+        """
+        if not chaos_events:
+            return False
+
+        # Map logical node_id -> port using initial_nodes from cluster connection
+        logical_id_to_port = {}
+        if self.cluster_connection and self.cluster_connection.initial_nodes:
+            for node in self.cluster_connection.initial_nodes:
+                logical_id_to_port[node.node_id] = node.port
+
+        # Build set of ports killed by successful chaos events
+        chaos_killed_ports = set()
+        for event in chaos_events:
+            if isinstance(event, ChaosResult) and event.success:
+                port = logical_id_to_port.get(event.target_node)
+                if port is not None:
+                    chaos_killed_ports.add(port)
+
+        if not chaos_killed_ports:
+            return False
+
+        # Every replica of this shard must be accounted for by a chaos kill
+        unaccounted = []
+        for replica in replica_nodes:
+            if replica.get('port') not in chaos_killed_ports:
+                unaccounted.append(f"{replica.get('host')}:{replica.get('port')}")
+
+        if unaccounted:
+            log.warning(
+                f"Replica(s) {unaccounted} are dead but were not killed by chaos. "
+                f"This is an unexpected failure."
+            )
+            return False
+
+        killed_ports = sorted(chaos_killed_ports)
+        log.info(
+            f"Failover skipped: all replicas of this shard were killed by chaos "
+            f"(killed ports: {killed_ports}). Treating as expected outcome."
+        )
+        return True
 
     def wait_for_operation_completion(self, timeout: float, log=None) -> bool:
         """Wait for operation to complete and validate cluster state"""

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -78,38 +78,48 @@ class OperationOrchestrator(IOperationOrchestrator):
         """Execute failover operation"""
         if log is None:
             log = logging
-        
+
         log.info(f"Executing failover on {operation.target_node}")
-        
-        # Get all cluster nodes (including dead ones) to find target primary
-        # Gets actual Node information from Valkey
-        current_nodes = self.cluster_connection.get_current_nodes()
-        
-        # Find target primary node
+
+        # Get live cluster nodes (exclude failed) to find the CURRENT primary
+        # After a previous failover, the original primary may be dead and a replica promoted
+        current_nodes = self.cluster_connection.get_current_nodes(include_failed=False)
+
+        # Find target primary node from live nodes only
         target_node = find_primary_node_by_identifier(current_nodes, operation.target_node)
-        
+
         if not target_node:
+            # Primary not found among live nodes — check if it was killed by chaos
+            all_nodes = self.cluster_connection.get_current_nodes(include_failed=True)
+            dead_primary = find_primary_node_by_identifier(all_nodes, operation.target_node)
+            if dead_primary and dead_primary.get('status') == 'failed':
+                if self._is_node_killed_by_chaos(dead_primary, chaos_events, log):
+                    log.info(
+                        f"Target primary {operation.target_node} was killed by chaos — "
+                        f"failover not possible, treating as expected outcome"
+                    )
+                    return True
             log.error(f"Target primary node {operation.target_node} not found in cluster")
             return False
-        
+
         # Get replicas of this primary to execute failover
         # Use cluster_connection to find replicas from any live node (resilient to dead primary)
         target_node_id = target_node['node_id']
         target_shard_id = target_node.get('shard_id')
-        
+
         log.info(f"Finding replicas for primary {operation.target_node} (node_id: {target_node_id})")
-        
+
         try:
             # Get fresh cluster topology from any live node
             current_nodes = self.cluster_connection.get_current_nodes()
-            
+
             if not current_nodes:
                 log.error("Cannot get current cluster nodes - all nodes may be down")
                 return False
-            
+
             # Find replicas of the target primary by shard_id or by querying a live node
             replica_nodes = []
-            
+
             # Strategy 1: Find replicas by shard_id (if available)
             if target_shard_id is not None:
                 for node in current_nodes:
@@ -120,30 +130,30 @@ class OperationOrchestrator(IOperationOrchestrator):
                             'node_id': node['node_id']
                         })
                         log.info(f"Found replica by shard_id: {node['node_id']} at port {node['port']}")
-            
+
             # Strategy 2: Query a live node for cluster topology
             # Try the target primary first for determinism, then fall back to other nodes
             if not replica_nodes:
                 log.info("Querying live nodes for replica information")
-                
+
                 # Build query order: target primary first, then other nodes
                 nodes_to_query = []
-                
+
                 # Add target primary first (if it's in current_nodes)
                 for node in current_nodes:
                     if node.get('node_id') == target_node_id or node.get('port') == target_node.get('port'):
                         nodes_to_query.append(node)
                         break
-                
+
                 # Add remaining nodes as fallback
                 for node in current_nodes:
                     if node not in nodes_to_query:
                         nodes_to_query.append(node)
-                
+
                 # Query nodes in priority order
                 for node in nodes_to_query:
                     parsed_nodes = query_cluster_nodes(node, timeout=3.0)
-                    
+
                     if parsed_nodes:
                         # Find replicas of our target primary
                         for parsed_node in parsed_nodes:
@@ -154,26 +164,26 @@ class OperationOrchestrator(IOperationOrchestrator):
                                     'node_id': parsed_node['node_id']
                                 })
                                 log.info(f"Found replica via CLUSTER NODES from {node['port']}: port {parsed_node['port']}")
-                        
+
                         # If we found replicas, break out of the loop
                         if replica_nodes:
                             break
-            
+
             if not replica_nodes:
                 log.error(f"Cannot execute failover: No replicas found for primary {operation.target_node}. "
                              f"Failover requires at least one replica to promote.")
                 return False
-            
+
             # Find a random alive replica to execute failover
             replica = self.cluster_connection.find_alive_node(replica_nodes, randomize=True)
-            
+
             if not replica:
                 log.error(f"Cannot execute failover: No alive replicas found for primary {operation.target_node}")
                 return self._all_replicas_killed_by_chaos(replica_nodes, chaos_events, log)
-            
+
             log.info(f"Selected alive replica at port {replica['port']} for failover")
             log.info(f"Executing CLUSTER FAILOVER from replica at port {replica['port']}")
-            
+
             with valkey_client(replica['host'], replica['port'], timeout=5.0, decode_responses=True) as replica_client:
                 # Execute CLUSTER FAILOVER command
                 force = operation.parameters.get('force', False)
@@ -183,13 +193,32 @@ class OperationOrchestrator(IOperationOrchestrator):
                 else:
                     replica_client.execute_command('CLUSTER', 'FAILOVER')
                     log.info("Executed graceful failover")
-            
+
             # Wait for failover to complete then validate cluster slots and replication links
             return self.wait_for_operation_completion(operation.timing.timeout, log)
-            
+
         except Exception as e:
             log.error(f"Failover execution failed: {e}")
             return False
+
+    def _is_node_killed_by_chaos(self, node, chaos_events, log) -> bool:
+        """Check if a specific node was killed by a chaos event."""
+        if not chaos_events:
+            return False
+
+        # Map logical node_id -> port using initial_nodes
+        logical_id_to_port = {}
+        if self.cluster_connection and self.cluster_connection.initial_nodes:
+            for n in self.cluster_connection.initial_nodes:
+                logical_id_to_port[n.node_id] = n.port
+
+        node_port = node.get('port')
+        for event in chaos_events:
+            if isinstance(event, ChaosResult) and event.success:
+                killed_port = logical_id_to_port.get(event.target_node)
+                if killed_port is not None and killed_port == node_port:
+                    return True
+        return False
 
     def _all_replicas_killed_by_chaos(self, replica_nodes, chaos_events, log) -> bool:
         """Check if every replica of the shard was killed by chaos injection"""
@@ -220,17 +249,9 @@ class OperationOrchestrator(IOperationOrchestrator):
                 unaccounted.append(f"{replica.get('host')}:{replica.get('port')}")
 
         if unaccounted:
-            log.warning(
-                f"Replica(s) {unaccounted} are dead but were not killed by chaos. "
-                f"This is an unexpected failure."
-            )
             return False
 
         killed_ports = sorted(chaos_killed_ports)
-        log.info(
-            f"Failover skipped: all replicas of this shard were killed by chaos "
-            f"(killed ports: {killed_ports}). Treating as expected outcome."
-        )
         return True
 
     def wait_for_operation_completion(self, timeout: float, log=None) -> bool:

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -89,16 +89,38 @@ class OperationOrchestrator(IOperationOrchestrator):
         target_node = find_primary_node_by_identifier(current_nodes, operation.target_node)
 
         if not target_node:
-            # Primary not found among live nodes — check if it was killed by chaos
+            # Primary not found among live nodes — check if it was killed by chaos.
             all_nodes = self.cluster_connection.get_current_nodes(include_failed=True)
             dead_primary = find_primary_node_by_identifier(all_nodes, operation.target_node)
             if dead_primary and dead_primary.get('status') == 'failed':
                 if self._is_node_killed_by_chaos(dead_primary, chaos_events, log):
-                    log.info(
-                        f"Target primary {operation.target_node} was killed by chaos — "
-                        f"failover not possible, treating as expected outcome"
-                    )
-                    return True
+                    # The primary was chaos-killed. If replicas are alive, Valkey's
+                    # automatic failover should be promoting one:
+                    #   1. Whole shard down (no live replicas) → expected, return True
+                    #   2. Replicas alive → auto-failover in progress, wait and verify
+                    target_node_id = dead_primary.get('node_id')
+                    target_shard_id = dead_primary.get('shard_id')
+                    live_nodes = self.cluster_connection.get_current_nodes(include_failed=False)
+                    has_live_replicas = False
+
+                    if target_shard_id is not None and live_nodes:
+                        has_live_replicas = any(n.get('role') == 'replica' and n.get('shard_id') == target_shard_id for n in live_nodes)
+
+                    if not has_live_replicas and target_node_id and live_nodes:
+                        for node in live_nodes:
+                            parsed_nodes = query_cluster_nodes(node, timeout=3.0)
+                            if parsed_nodes:
+                                has_live_replicas = any(
+                                    p['is_slave'] and p['master_id'] == target_node_id
+                                    for p in parsed_nodes
+                                )
+                                if has_live_replicas:
+                                    break
+
+                    if has_live_replicas:
+                        return self.wait_for_operation_completion(operation.timing.timeout, log)
+                    else:
+                        return True
             log.error(f"Target primary node {operation.target_node} not found in cluster")
             return False
 

--- a/src/fuzzer_engine/operation_orchestrator.py
+++ b/src/fuzzer_engine/operation_orchestrator.py
@@ -192,14 +192,7 @@ class OperationOrchestrator(IOperationOrchestrator):
             return False
 
     def _all_replicas_killed_by_chaos(self, replica_nodes, chaos_events, log) -> bool:
-        """Check if every replica of the shard was killed by chaos injection.
-        
-        Returns True only if ALL dead replicas can be accounted for by a matching
-        chaos event. If any replica is dead for an unexplained reason, returns False.
-        
-        Uses port-based matching because chaos events use logical node IDs (e.g. "node-0")
-        while replica_nodes from CLUSTER NODES use Valkey cluster hex IDs.
-        """
+        """Check if every replica of the shard was killed by chaos injection"""
         if not chaos_events:
             return False
 

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -78,7 +78,7 @@ class ParallelExecutor:
 
                 success = self.operation_orchestrator.execute_operation(
                     operation, log_buffer=buffer,
-                    chaos_events=self.chaos_coordinator.chaos_history
+                    chaos_events=immediate_chaos
                 )
 
                 for deferred in deferred_chaos:

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -76,7 +76,10 @@ class ParallelExecutor:
                     if isinstance(chaos, dict) and chaos.get("deferred")
                 ]
 
-                success = self.operation_orchestrator.execute_operation(operation, log_buffer=buffer)
+                success = self.operation_orchestrator.execute_operation(
+                    operation, log_buffer=buffer,
+                    chaos_events=self.chaos_coordinator.chaos_history
+                )
 
                 for deferred in deferred_chaos:
                     buffer.info(f"Injecting deferred chaos after operation (delay: {deferred['delay']:.2f}s)")

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -1122,12 +1122,14 @@ class TopologyValidator:
                 # With replicas, failover maintains primary count UNLESS the entire shard is killed
                 if chaos_killed_shards is None:
                     chaos_killed_shards = set()
-                fully_killed_primary_count = sum(
-                    1 for node in failed_nodes
+                # Count fully-killed shards (not nodes) to avoid double-counting
+                # when a shard had multiple primary promotions before being fully killed
+                fully_killed_primary_count = len({
+                    node.get('shard_id') for node in failed_nodes
                     if is_node_killed_by_chaos(node, killed_nodes)
                     and killed_node_roles.get(format_node_address(node), node['role']) == 'primary'
                     and node.get('shard_id') in chaos_killed_shards
-                )
+                })
                 # Primaries in fully-killed shards can't be replaced; others can via failover
                 adjusted_expected_primaries = expected_topology.num_primaries - fully_killed_primary_count
             

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -705,7 +705,8 @@ class SlotCoverageValidator:
         self,
         cluster_connection: ClusterConnection,
         config: SlotCoverageValidationConfig,
-        killed_nodes: Optional[set[str]] = None
+        killed_nodes: Optional[set[str]] = None,
+        chaos_killed_shards: Optional[set[int]] = None
     ) -> SlotCoverageValidation:
         """Check slot coverage across the cluster from all nodes' perspectives."""
         try:
@@ -845,6 +846,33 @@ class SlotCoverageValidator:
             # Initialize killed_nodes if not provided
             if killed_nodes is None:
                 killed_nodes = set()
+            if chaos_killed_shards is None:
+                chaos_killed_shards = set()
+
+            # Build set of slots belonging to fully chaos-killed shards
+            slots_on_fully_killed_shards = set()
+            if chaos_killed_shards:
+                for node in all_nodes:
+                    shard_id = node.get('shard_id')
+                    if shard_id in chaos_killed_shards and node['role'] == 'primary':
+                        node_id = node['node_id']
+                        if node_id in slot_distribution:
+                            slots_on_fully_killed_shards.update(slot_distribution[node_id])
+                # Also check unassigned slots that were previously owned by killed shard primaries by looking at the consensus view from before the nodes died
+                for node_addr, slot_view in node_perspectives.items():
+                    for slot, owner_id in slot_view.items():
+                        # Find if this owner belongs to a fully killed shard
+                        for node in all_nodes:
+                            if node['node_id'] == owner_id and node.get('shard_id') in chaos_killed_shards:
+                                slots_on_fully_killed_shards.add(slot)
+                                break
+
+                if slots_on_fully_killed_shards:
+                    logger.info(
+                        f"Excluding {len(slots_on_fully_killed_shards)} slots from fully chaos-killed "
+                        f"shard(s) {sorted(chaos_killed_shards)}: "
+                        f"{group_slots_into_ranges(sorted(slots_on_fully_killed_shards))}"
+                    )
 
             # CRITICAL: Check if slots are assigned to killed nodes
             if killed_nodes:
@@ -862,22 +890,42 @@ class SlotCoverageValidator:
                         slots_on_killed_nodes.extend(slot_distribution[node_id])
 
                 if slots_on_killed_nodes:
-                    success = False
-                    error_message = (
-                        f"CRITICAL: {len(slots_on_killed_nodes)} slots still assigned to killed nodes. "
-                        f"Killed nodes: {killed_nodes}. "
-                        f"This indicates failover did not complete or slots were not reassigned. "
-                        f"Affected slots: {group_slots_into_ranges(slots_on_killed_nodes)}"
-                    )
-                    logger.error(error_message)
+                    # Exclude slots from fully chaos-killed shards — those have no node to failover to
+                    unexpected_slots_on_killed = [
+                        s for s in slots_on_killed_nodes if s not in slots_on_fully_killed_shards
+                    ]
+                    if unexpected_slots_on_killed:
+                        success = False
+                        error_message = (
+                            f"CRITICAL: {len(unexpected_slots_on_killed)} slots still assigned to killed nodes. "
+                            f"Killed nodes: {killed_nodes}. "
+                            f"This indicates failover did not complete or slots were not reassigned. "
+                            f"Affected slots: {group_slots_into_ranges(unexpected_slots_on_killed)}"
+                        )
+                        logger.error(error_message)
+                    elif slots_on_killed_nodes:
+                        logger.info(
+                            f"{len(slots_on_killed_nodes)} slots on killed nodes belong to fully "
+                            f"chaos-killed shards — expected, not a failure"
+                        )
 
             if success and config.require_full_coverage and unassigned_slots:
-                success = False
-                error_message = (
-                    f"{len(unassigned_slots)} slots are unassigned "
-                    f"(expected all 16384 slots to be assigned)"
-                )
-                logger.error(error_message)
+                # Exclude unassigned slots from fully chaos-killed shards
+                unexpected_unassigned = [
+                    s for s in unassigned_slots if s not in slots_on_fully_killed_shards
+                ]
+                if unexpected_unassigned:
+                    success = False
+                    error_message = (
+                        f"{len(unexpected_unassigned)} slots are unassigned "
+                        f"(expected all 16384 slots to be assigned)"
+                    )
+                    logger.error(error_message)
+                elif unassigned_slots:
+                    logger.info(
+                        f"{len(unassigned_slots)} unassigned slots belong to fully chaos-killed "
+                        f"shards — expected, not a failure"
+                    )
 
             if success and not config.allow_slot_conflicts and conflicting_slots:
                 success = False
@@ -985,7 +1033,8 @@ class TopologyValidator:
         expected_topology: Optional['ExpectedTopology'],
         config: 'TopologyValidationConfig',
         killed_nodes: Optional[set] = None,
-        killed_node_roles: Optional[dict] = None
+        killed_node_roles: Optional[dict] = None,
+        chaos_killed_shards: Optional[set[int]] = None
     ) -> 'TopologyValidation':
         try:
             if killed_nodes is None:
@@ -1070,8 +1119,17 @@ class TopologyValidator:
             if expected_topology.num_replicas == 0:
                 adjusted_expected_primaries = expected_topology.num_primaries - killed_primaries
             else:
-                # With replicas, failover maintains primary count
-                adjusted_expected_primaries = expected_topology.num_primaries
+                # With replicas, failover maintains primary count UNLESS the entire shard is killed
+                if chaos_killed_shards is None:
+                    chaos_killed_shards = set()
+                fully_killed_primary_count = sum(
+                    1 for node in failed_nodes
+                    if is_node_killed_by_chaos(node, killed_nodes)
+                    and killed_node_roles.get(format_node_address(node), node['role']) == 'primary'
+                    and node.get('shard_id') in chaos_killed_shards
+                )
+                # Primaries in fully-killed shards can't be replaced; others can via failover
+                adjusted_expected_primaries = expected_topology.num_primaries - fully_killed_primary_count
             
             adjusted_expected_replicas = max(0, expected_topology.num_replicas - total_killed_nodes)
             
@@ -2212,6 +2270,10 @@ class StateValidator:
         self.shards_with_primary_killed: set[int] = set()
         # Track killed node roles at time of death: node_address -> role
         self.killed_node_roles: dict[str, str] = {}
+        # Track killed nodes per shard: shard_id -> set of killed node addresses
+        self.killed_nodes_by_shard: dict[int, set[str]] = {}
+        # Total nodes per shard (set during validation setup): shard_id -> count
+        self.nodes_per_shard: dict[int, int] = {}
 
         logger.debug("StateValidator initialized")
 
@@ -2221,6 +2283,9 @@ class StateValidator:
         self.killed_node_roles[node_address] = node_role
         if node_role == 'primary':
             self.shards_with_primary_killed.add(shard_id)
+        if shard_id not in self.killed_nodes_by_shard:
+            self.killed_nodes_by_shard[shard_id] = set()
+        self.killed_nodes_by_shard[shard_id].add(node_address)
         logger.debug(f"Registered killed node: {node_address} (role: {node_role}, shard: {shard_id})")
 
     def clear_killed_nodes(self) -> None:
@@ -2228,7 +2293,22 @@ class StateValidator:
         self.killed_nodes.clear()
         self.shards_with_primary_killed.clear()
         self.killed_node_roles.clear()
+        self.killed_nodes_by_shard.clear()
+        self.nodes_per_shard.clear()
         logger.debug("Cleared killed nodes list")
+
+    def set_nodes_per_shard(self, nodes_per_shard: dict[int, int]) -> None:
+        """Set the total node count per shard (primary + replicas) for full-shard-kill detection."""
+        self.nodes_per_shard = dict(nodes_per_shard)
+
+    def get_chaos_killed_shards(self) -> set[int]:
+        """Return shard IDs where ALL nodes have been killed by chaos"""
+        fully_killed = set()
+        for shard_id, killed in self.killed_nodes_by_shard.items():
+            total = self.nodes_per_shard.get(shard_id, 0)
+            if total > 0 and len(killed) >= total:
+                fully_killed.add(shard_id)
+        return fully_killed
 
     def write_test_data(self, cluster_connection: ClusterConnection) -> bool:
         if not self.config.check_data_consistency:
@@ -2408,12 +2488,14 @@ class StateValidator:
                         raise ValidationTimeoutError(
                             f"Validation timeout ({self.config.validation_timeout}s) exceeded"
                         )
+                    chaos_killed_shards = self.get_chaos_killed_shards()
                     slot_coverage_result = self._run_validation_check(
                         check_name="slot_coverage",
                         validator_func=lambda: self.slot_validator.validate(
                             cluster_connection,
                             self.config.slot_coverage_config,
-                            killed_nodes=self.killed_nodes
+                            killed_nodes=self.killed_nodes,
+                            chaos_killed_shards=chaos_killed_shards
                         ),
                         failed_checks=failed_checks,
                         error_messages=error_messages,
@@ -2424,6 +2506,7 @@ class StateValidator:
                 if self.config.check_topology and expected_topology:
                     if time.time() >= timeout_deadline:
                         raise ValidationTimeoutError(f"Validation timeout ({self.config.validation_timeout}s) exceeded")
+                    chaos_killed_shards = self.get_chaos_killed_shards()
                     topology_result = self._run_validation_check(
                         check_name="topology",
                         validator_func=lambda: self.topology_validator.validate(
@@ -2431,7 +2514,8 @@ class StateValidator:
                             expected_topology,
                             self.config.topology_config,
                             self.killed_nodes,
-                            self.killed_node_roles
+                            self.killed_node_roles,
+                            chaos_killed_shards=chaos_killed_shards
                         ),
                         failed_checks=failed_checks,
                         error_messages=error_messages

--- a/src/fuzzer_engine/state_validator.py
+++ b/src/fuzzer_engine/state_validator.py
@@ -1105,17 +1105,7 @@ class TopologyValidator:
             
             total_killed_nodes = killed_primaries + killed_replicas
             
-            # Adjust expectations:
-            # - Primary count: stays the same if replicas can promote, otherwise reduces by killed primaries
-            #   * With replicas: failover promotes replicas to replace killed primaries
-            #   * Without replicas: killed primaries reduce the primary count
-            # - Replica count reduces by ALL killed nodes:
-            #   * Each killed replica directly reduces replica count
-            #   * Each killed primary causes a replica to promote (also reduces replica count)
-            # - Clamp replica count at 0 to handle zero-replica scenarios where killing primaries
-            #   would otherwise make the expected count negative
-            
-            # In zero-replica clusters, killed primaries reduce the primary count
+            fully_killed_primary_count = 0
             if expected_topology.num_replicas == 0:
                 adjusted_expected_primaries = expected_topology.num_primaries - killed_primaries
             else:
@@ -1133,7 +1123,8 @@ class TopologyValidator:
                 # Primaries in fully-killed shards can't be replaced; others can via failover
                 adjusted_expected_primaries = expected_topology.num_primaries - fully_killed_primary_count
             
-            adjusted_expected_replicas = max(0, expected_topology.num_replicas - total_killed_nodes)
+            promoted_primaries = killed_primaries - fully_killed_primary_count if chaos_killed_shards else killed_primaries
+            adjusted_expected_replicas = max(0, expected_topology.num_replicas - killed_replicas - promoted_primaries)
             
             if total_killed_nodes > 0:
                 logger.info(

--- a/src/fuzzer_engine/test_case_generator.py
+++ b/src/fuzzer_engine/test_case_generator.py
@@ -62,8 +62,9 @@ class ScenarioGenerator(ITestCaseGenerator):
         )
     
     def _generate_random_operations(self, cluster_config: ClusterConfig) -> List[Operation]:
-        """Generate random failover operations"""
-        num_operations = random.randint(1, 5)
+        """Generate random failover operations."""
+        max_safe_operations = cluster_config.replicas_per_shard * cluster_config.num_shards
+        num_operations = random.randint(1, min(5, max_safe_operations))
         operations = []
         num_primaries = cluster_config.num_shards
         

--- a/src/fuzzer_engine/test_case_generator.py
+++ b/src/fuzzer_engine/test_case_generator.py
@@ -52,7 +52,7 @@ class ScenarioGenerator(ITestCaseGenerator):
         """Generate random cluster configuration"""
         num_shards = random.randint(3, 16)
         # Ensure at least 1 replica per shard for failover operations
-        replicas_per_shard = random.randint(1, 2)
+        replicas_per_shard = random.randint(1, 5)
         base_port = random.randint(7000, 8000)
         
         return ClusterConfig(
@@ -162,8 +162,8 @@ class ScenarioGenerator(ITestCaseGenerator):
         
         if not (3 <= num_shards <= 16):
             raise ValueError(f"num_shards must be between 3 and 16, got {num_shards}")
-        if not (0 <= replicas_per_shard <= 2):
-            raise ValueError(f"replicas_per_shard must be between 0 and 2, got {replicas_per_shard}")
+        if not (0 <= replicas_per_shard <= 5):
+            raise ValueError(f"replicas_per_shard must be between 0 and 5, got {replicas_per_shard}")
         
         kwargs = {
             'num_shards': num_shards,
@@ -387,7 +387,7 @@ class ScenarioGenerator(ITestCaseGenerator):
         """Validate test scenario configuration, raises ValueError if invalid."""
         if not (3 <= scenario.cluster_config.num_shards <= 16):
             raise ValueError(f"Invalid num_shards: {scenario.cluster_config.num_shards}")
-        if not (0 <= scenario.cluster_config.replicas_per_shard <= 2):
+        if not (0 <= scenario.cluster_config.replicas_per_shard <= 5):
             raise ValueError(f"Invalid replicas_per_shard: {scenario.cluster_config.replicas_per_shard}")
         
         if not scenario.operations:

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -141,7 +141,7 @@ class IOperationOrchestrator(ABC):
     """Interface for operation execution"""
     
     @abstractmethod
-    def execute_operation(self, operation: Operation, log_buffer=None) -> bool:
+    def execute_operation(self, operation: Operation, log_buffer=None, chaos_events=None) -> bool:
         """Execute a single cluster operation"""
         pass
 

--- a/tests/test_test_case_generator.py
+++ b/tests/test_test_case_generator.py
@@ -33,7 +33,7 @@ def test_generate_random_scenario_without_seed():
     # Should have valid configuration
     assert 3 <= scenario.cluster_config.num_shards <= 16
     # Ensure at least 1 replica for failover operations
-    assert 1 <= scenario.cluster_config.replicas_per_shard <= 2
+    assert 1 <= scenario.cluster_config.replicas_per_shard <= 5
     assert len(scenario.operations) >= 1
     assert scenario.seed is not None
 
@@ -46,7 +46,7 @@ def test_random_cluster_config_ranges():
         scenario = generator.generate_random_scenario()
         assert 3 <= scenario.cluster_config.num_shards <= 16
         # Ensure at least 1 replica for failover operations
-        assert 1 <= scenario.cluster_config.replicas_per_shard <= 2
+        assert 1 <= scenario.cluster_config.replicas_per_shard <= 5
 
 
 def test_random_operations_are_failover():


### PR DESCRIPTION
**Changes**

- Increase range of replicas from 1-2 to 1-5
- When no replicas are alive we shouldn't mark the attempted failover as a failure.
- If an entire shard is killed due to chaos we shouldn't mark this as a failure
- We shouldn't lose cluster quorum if we have more operations than shards.