### PR TITLE
fix: tolerate operation failures during chaos when all validations pass

### DIFF
--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -112,6 +112,7 @@ class ChaosCoordinator:
                 time.sleep(delay_before)
                 
                 result = self._inject_chaos(target_node, chaos_config, should_randomize, log, cluster_connection)
+                result.chaos_phase = "before"
                 chaos_results.append(result)
                 
                 if result.success:
@@ -122,6 +123,7 @@ class ChaosCoordinator:
                 log.info("Injecting chaos during operation execution")
                 
                 result = self._inject_chaos(target_node, chaos_config, should_randomize, log, cluster_connection)
+                result.chaos_phase = "during"
                 chaos_results.append(result)
                 
                 if result.success:

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -16,7 +16,7 @@ from .test_logger import FuzzerLogger
 from .error_handler import ErrorHandler, ErrorContext, ErrorCategory, ErrorSeverity, RetryConfig
 from .state_validator import StateValidator
 from .parallel_executor import ParallelExecutor
-from ..models import StateValidationConfig, ExpectedTopology, ChaosType
+from ..models import StateValidationConfig, ExpectedTopology, ChaosType, ChaosResult
 
 logger = logging.getLogger()
 
@@ -257,7 +257,8 @@ class FuzzerEngine(IFuzzerEngine):
                 operations_executed=operations_executed,
                 chaos_events=chaos_events,
                 validation_results=validation_results,
-                final_validation_result=final_validation_result
+                final_validation_result=final_validation_result,
+                chaos_config=scenario.chaos_config
             )
             success = len(failure_reasons) == 0
             
@@ -404,16 +405,58 @@ class FuzzerEngine(IFuzzerEngine):
         operations_executed: int,
         chaos_events: List,
         validation_results: List,
-        final_validation_result
+        final_validation_result,
+        chaos_config=None
     ) -> List[str]:
-        """Summarize all execution failures that should make the run fail."""
+        """Summarize all execution failures that should make the run fail.
+
+        Operation failures are tolerated when chaos was injected before or
+        during operations and all final validations pass.  Chaos that fires
+        only *after* operations cannot explain an operation failure, so those
+        are still treated as real failures.
+
+        When ``randomize_per_operation`` is enabled the coordination mode is
+        randomized per operation, so any operation may have had before/during
+        chaos — tolerance applies in that case as well.
+        """
         failure_reasons = []
+
+        # Check for at least one successful before/during chaos event.
+        # Each ChaosResult now carries a chaos_phase tag ("before", "during",
+        # or "after") set by the coordinator / parallel executor.
+        has_interfering_chaos = False
+        if chaos_config:
+            has_interfering_chaos = any(
+                isinstance(event, ChaosResult)
+                and event.success
+                and event.chaos_phase in ("before", "during")
+                for event in chaos_events
+            )
+
+            # When randomize_per_operation is enabled, the phase is randomized
+            # per operation so any successful event could have been before/during.
+            if not has_interfering_chaos and chaos_config.randomize_per_operation:
+                has_interfering_chaos = any(
+                    isinstance(event, ChaosResult) and event.success
+                    for event in chaos_events
+                )
+
+        all_validations_passed = final_validation_result.overall_success
 
         if operations_executed != total_operations:
             failed_operations = total_operations - operations_executed
-            failure_reasons.append(f"{failed_operations} operation(s) failed")
+            if has_interfering_chaos and all_validations_passed:
+                # Chaos was active before/during operations and the cluster
+                # recovered — operation failures are expected (timeouts,
+                # killed targets, etc.)
+                logger.info(
+                    f"{failed_operations} operation(s) failed during chaos, "
+                    "but all validations passed — tolerating as expected chaos interaction"
+                )
+            else:
+                failure_reasons.append(f"{failed_operations} operation(s) failed")
 
-        failed_chaos_events = [event for event in chaos_events if not event.success]
+        failed_chaos_events = [event for event in chaos_events if isinstance(event, ChaosResult) and not event.success]
         if failed_chaos_events:
             failure_reasons.append(f"{len(failed_chaos_events)} chaos injection(s) failed")
 

--- a/src/fuzzer_engine/parallel_executor.py
+++ b/src/fuzzer_engine/parallel_executor.py
@@ -101,6 +101,7 @@ class ParallelExecutor:
                         buffer,
                         cluster_connection,
                     )
+                    result.chaos_phase = "after"
                     immediate_chaos.append(result)
                     if isinstance(result, ChaosResult):
                         self.chaos_coordinator.chaos_history.append(result)

--- a/src/models.py
+++ b/src/models.py
@@ -197,6 +197,7 @@ class ChaosResult:
     end_time: Optional[float] = None
     error_message: Optional[str] = None
     target_role: Optional[str] = None
+    chaos_phase: Optional[str] = None  # "before", "during", or "after"
 
 
 @dataclass

--- a/tests/test_collect_failure_reasons.py
+++ b/tests/test_collect_failure_reasons.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for _collect_failure_reasons — specifically the chaos-tolerance logic.
+
+Each test targets a concrete edge case raised during code review.
+"""
+import time
+from unittest.mock import Mock
+
+from src.fuzzer_engine.fuzzer_engine import FuzzerEngine
+from src.models import (
+    ChaosConfig,
+    ChaosCoordination,
+    ChaosResult,
+    ChaosTiming,
+    ChaosType,
+    ProcessChaosType,
+    TargetSelection,
+)
+
+
+def _chaos_event(success: bool, phase: str = "during") -> ChaosResult:
+    return ChaosResult(
+        chaos_id="c1",
+        chaos_type=ChaosType.PROCESS_KILL,
+        target_node="node-0",
+        success=success,
+        start_time=time.time(),
+        end_time=time.time(),
+        chaos_phase=phase,
+    )
+
+
+def _validation(overall_success: bool):
+    v = Mock()
+    v.overall_success = overall_success
+    v.failed_checks = [] if overall_success else ["topology"]
+    return v
+
+
+def _chaos_config(before=False, during=False, after=False, randomize=False):
+    return ChaosConfig(
+        chaos_type=ChaosType.PROCESS_KILL,
+        target_selection=TargetSelection(strategy="random"),
+        timing=ChaosTiming(),
+        coordination=ChaosCoordination(
+            chaos_before_operation=before,
+            chaos_during_operation=during,
+            chaos_after_operation=after,
+        ),
+        process_chaos_type=ProcessChaosType.SIGKILL,
+        randomize_per_operation=randomize,
+    )
+
+
+engine = FuzzerEngine()
+
+
+# ── Basic: no chaos config at all ──────────────────────────────────────
+
+def test_no_chaos_config_operation_failure_is_real():
+    """Without any chaos config, operation failures must always be reported."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=3,
+        operations_executed=2,
+        chaos_events=[_chaos_event(True)],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=None,
+    )
+    assert any("1 operation(s) failed" in r for r in reasons)
+
+
+# ── During-chaos: the common case ──────────────────────────────────────
+
+def test_during_chaos_all_validations_pass_tolerates():
+    """During-chaos + all validations pass → tolerate operation failures."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=3,
+        operations_executed=1,
+        chaos_events=[_chaos_event(True), _chaos_event(True)],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(during=True),
+    )
+    assert not any("operation(s) failed" in r for r in reasons)
+
+
+def test_during_chaos_validation_fails_not_tolerated():
+    """During-chaos but final validation fails → operation failure reported."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=3,
+        operations_executed=2,
+        chaos_events=[_chaos_event(True)],
+        validation_results=[],
+        final_validation_result=_validation(False),
+        chaos_config=_chaos_config(during=True),
+    )
+    assert any("1 operation(s) failed" in r for r in reasons)
+
+
+# ── After-only chaos: must NOT tolerate ────────────────────────────────
+
+def test_after_only_chaos_not_tolerated():
+    """chaos_after_operation only — operation ran before chaos, failure is real."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=3,
+        operations_executed=2,
+        chaos_events=[_chaos_event(True, phase="after")],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(after=True),
+    )
+    assert any("1 operation(s) failed" in r for r in reasons)
+
+
+# ── Mixed before/during + after: the tricky edge case ─────────────────
+
+def test_mixed_before_and_after_all_before_failed():
+    """before + after enabled, but only after-events succeeded.
+
+    The before-events all failed, so no chaos actually interfered with
+    operations.  Must NOT tolerate.
+    """
+    reasons = engine._collect_failure_reasons(
+        total_operations=2,
+        operations_executed=1,
+        chaos_events=[
+            _chaos_event(False, phase="before"),  # before op-1 failed
+            _chaos_event(True, phase="after"),     # after op-1 succeeded
+            _chaos_event(False, phase="before"),  # before op-2 failed
+            _chaos_event(True, phase="after"),     # after op-2 succeeded
+        ],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(before=True, after=True),
+    )
+    assert any("1 operation(s) failed" in r for r in reasons)
+
+
+def test_mixed_during_and_after_some_during_succeeded():
+    """during + after enabled, and at least one during-event succeeded.
+    Should tolerate.
+    """
+    reasons = engine._collect_failure_reasons(
+        total_operations=2,
+        operations_executed=1,
+        chaos_events=[
+            _chaos_event(True, phase="during"),   # during op-1
+            _chaos_event(True, phase="after"),    # after op-1
+            _chaos_event(True, phase="during"),   # during op-2
+            _chaos_event(False, phase="after"),   # after op-2 failed
+        ],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(during=True, after=True),
+    )
+    assert not any("operation(s) failed" in r for r in reasons)
+
+
+# ── randomize_per_operation ────────────────────────────────────────────
+
+def test_randomize_per_operation_tolerates():
+    """When randomize_per_operation is enabled, any operation may have had
+    before/during chaos, so tolerance applies."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=3,
+        operations_executed=2,
+        chaos_events=[_chaos_event(True)],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(after=True, randomize=True),
+    )
+    assert not any("operation(s) failed" in r for r in reasons)
+
+
+# ── No successful chaos events at all ──────────────────────────────────
+
+def test_during_chaos_all_events_failed_not_tolerated():
+    """Chaos was configured during but every injection failed — no
+    actual interference, so operation failure is real."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=2,
+        operations_executed=1,
+        chaos_events=[_chaos_event(False), _chaos_event(False)],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(during=True),
+    )
+    assert any("1 operation(s) failed" in r for r in reasons)
+
+
+# ── Chaos injection failures are always reported ───────────────────────
+
+def test_failed_chaos_injections_always_reported():
+    """Failed chaos injections are reported regardless of tolerance."""
+    reasons = engine._collect_failure_reasons(
+        total_operations=2,
+        operations_executed=2,
+        chaos_events=[_chaos_event(False)],
+        validation_results=[],
+        final_validation_result=_validation(True),
+        chaos_config=_chaos_config(during=True),
+    )
+    assert any("chaos injection(s) failed" in r for r in reasons)


### PR DESCRIPTION
## Problem

The fuzzer currently treats any operation failure as a run failure, even when all cluster validations pass. During chaos injection (nodes being killed), failover operations can fail transiently due to timeouts, connection errors, or killed targets. These transient failures don't indicate a Valkey bug if the cluster recovers correctly.

This causes false positive issue reports like:
- #76: One failover operation failed during chaos (+2 more)
- #80: Operation failure with all validations passing (+1 more)  
- #83: 2 failover operations failed during chaos
- #84: 2 failover operations reported as failed
- #86: Operation reported as failed despite all validations passing

## Fix

Updated `_collect_failure_reasons` in `FuzzerEngine` to tolerate operation failures when:
1. Chaos was actively injected (at least one successful chaos event), AND
2. All final validations passed (cluster status, slot coverage, topology, data consistency, replication, view consistency, log validation)

When both conditions are met, operation failures are logged as expected chaos interactions rather than counted as failure reasons.

## Testing

All 205 existing tests pass, including the strictness tests that verify chaos injection failures are still caught.