### PR TITLE
[codex] Increase fuzzer artifact retention to 60 days

### DIFF
--- a/.github/workflows/fuzzer-run.yml
+++ b/.github/workflows/fuzzer-run.yml
@@ -139,4 +139,4 @@ jobs:
         name: fuzzer-run-artifacts-${{ github.run_id }}
         path: ${{ env.FUZZER_ARTIFACT_DIR }}
         if-no-files-found: warn
-        retention-days: 14
+        retention-days: 60


### PR DESCRIPTION
## Summary
- increase the scheduled fuzzer run artifact retention from 14 days to 60 days
- keep the change scoped to the scheduled `fuzzer-run.yml` artifact upload step

## Why
The scheduled fuzzer runs execute every 4 hours, and a 60-day retention window makes it easier to compare failures and investigate regressions across longer time spans without jumping all the way to the maximum retention window.

## Validation
- `git diff --check`
