### PR TITLE
Prevent chaos from breaking primary quorum

### DIFF
--- a/src/chaos_engine/base.py
+++ b/src/chaos_engine/base.py
@@ -298,28 +298,94 @@ class ChaosTargetSelector:
 
         return safe
 
-    def is_shard_safety_exhausted(self, cluster_id: str, target_selection: TargetSelection) -> bool:
-        """Return True only when shard safety is the reason no target can be selected."""
+    def _get_quorum_safe_candidates(self, candidates: List[NodeInfo], cluster_id: str, log=None) -> List[NodeInfo]:
+        """Filter candidates to avoid killing primaries that would break cluster quorum.
+
+        The required quorum is based on the original shard count, because dead
+        primaries still count toward the failover majority until a replacement
+        takes over the shard.
+
+        Caller must hold ``_lock``.
+        """
+        initial_nodes = self._initial_topology.get(cluster_id, [])
+        if not initial_nodes:
+            return candidates
+
+        total_primaries = len({node.shard_id for node in initial_nodes})
+        if total_primaries == 0:
+            return candidates
+
+        quorum = (total_primaries // 2) + 1
+        killed = self._killed_node_ids.get(cluster_id, set())
+        live_primaries = {
+            node.node_id
+            for node in self.cluster_nodes.get(cluster_id, [])
+            if node.role == 'primary'
+        }
+
+        safe = []
+        for candidate in candidates:
+            if candidate.role != 'primary':
+                safe.append(candidate)
+                continue
+
+            surviving_primaries = live_primaries - killed - {candidate.node_id}
+            if len(surviving_primaries) >= quorum:
+                safe.append(candidate)
+            elif log is not None:
+                log.info(
+                    f"Skipping {candidate.node_id} (shard {candidate.shard_id}) — "
+                    f"killing it would leave {len(surviving_primaries)} live primaries, "
+                    f"below quorum {quorum}"
+                )
+
+        return safe
+
+    def _get_safe_candidates(self, candidates: List[NodeInfo], cluster_id: str, log=None) -> List[NodeInfo]:
+        """Apply shard and quorum safety checks to a candidate list.
+
+        Caller must hold ``_lock``.
+        """
+        shard_safe = self._get_shard_safe_candidates(candidates, cluster_id, log)
+        if not shard_safe:
+            return []
+        return self._get_quorum_safe_candidates(shard_safe, cluster_id, log)
+
+    def get_safety_block_reason(self, cluster_id: str, target_selection: TargetSelection) -> Optional[str]:
+        """Return the safety rule blocking target selection, if any."""
         with self._lock:
             nodes = self.cluster_nodes.get(cluster_id, [])
             if not nodes:
-                return False
+                return None
 
-            strategy = target_selection.strategy
-            if strategy == "random":
-                candidates = nodes
-            elif strategy == "primary_only":
-                candidates = [n for n in nodes if n.role == 'primary']
-            elif strategy == "replica_only":
-                candidates = [n for n in nodes if n.role == 'replica']
-            else:
-                return False
-
+            candidates = self._get_strategy_candidates(nodes, target_selection)
             if not candidates:
-                return False
+                return None
 
-            safe_candidates = self._get_shard_safe_candidates(candidates, cluster_id)
-            return len(safe_candidates) == 0
+            shard_safe = self._get_shard_safe_candidates(candidates, cluster_id)
+            if not shard_safe:
+                return "shard-safe"
+
+            quorum_safe = self._get_quorum_safe_candidates(shard_safe, cluster_id)
+            if not quorum_safe:
+                return "quorum-safe"
+
+            return None
+
+    def _get_strategy_candidates(
+        self,
+        nodes: List[NodeInfo],
+        target_selection: TargetSelection,
+    ) -> List[NodeInfo]:
+        """Return the nodes eligible for a selection strategy before safety filters."""
+        strategy = target_selection.strategy
+        if strategy == "random":
+            return nodes
+        if strategy == "primary_only":
+            return [node for node in nodes if node.role == 'primary']
+        if strategy == "replica_only":
+            return [node for node in nodes if node.role == 'replica']
+        return []
 
     def select_target(self, cluster_id: str, target_selection: TargetSelection, log_buffer=None) -> Optional[NodeInfo]:
         """Select a chaos target and eagerly reserve it as killed.
@@ -371,35 +437,35 @@ class ChaosTargetSelector:
             return selected
 
         elif strategy == "random":
-            safe_nodes = self._get_shard_safe_candidates(nodes, cluster_id, log)
+            safe_nodes = self._get_safe_candidates(nodes, cluster_id, log)
             if not safe_nodes:
-                log.warning("No shard-safe random targets available")
+                log.warning("No safe random targets available")
                 return None
             selected = self.rng.choice(safe_nodes)
             log.info(f"Selected random node: {selected.node_id} (shard {selected.shard_id})")
             return selected
 
         elif strategy == "primary_only":
-            primaries = [n for n in nodes if n.role == 'primary']
+            primaries = self._get_strategy_candidates(nodes, target_selection)
             if not primaries:
                 log.warning("No primary nodes available")
                 return None
-            safe_primaries = self._get_shard_safe_candidates(primaries, cluster_id, log)
+            safe_primaries = self._get_safe_candidates(primaries, cluster_id, log)
             if not safe_primaries:
-                log.warning("No shard-safe primary targets available")
+                log.warning("No safe primary targets available")
                 return None
             selected = self.rng.choice(safe_primaries)
             log.info(f"Selected random primary: {selected.node_id} (shard {selected.shard_id})")
             return selected
 
         elif strategy == "replica_only":
-            replicas = [n for n in nodes if n.role == 'replica']
+            replicas = self._get_strategy_candidates(nodes, target_selection)
             if not replicas:
                 log.warning("No replica nodes available")
                 return None
-            safe_replicas = self._get_shard_safe_candidates(replicas, cluster_id, log)
+            safe_replicas = self._get_safe_candidates(replicas, cluster_id, log)
             if not safe_replicas:
-                log.warning("No shard-safe replica targets available")
+                log.warning("No safe replica targets available")
                 return None
             selected = self.rng.choice(safe_replicas)
             log.info(f"Selected random replica: {selected.node_id} (shard {selected.shard_id})")

--- a/src/fuzzer_engine/chaos_coordinator.py
+++ b/src/fuzzer_engine/chaos_coordinator.py
@@ -84,13 +84,14 @@ class ChaosCoordinator:
             target_node = self.chaos_engine.target_selector.select_target(cluster_id, chaos_config.target_selection, log_buffer=log)
             
             if not target_node:
-                if self.chaos_engine.target_selector.is_shard_safety_exhausted(
+                safety_block_reason = self.chaos_engine.target_selector.get_safety_block_reason(
                     cluster_id,
                     chaos_config.target_selection,
-                ):
+                )
+                if safety_block_reason:
                     log.warning(
                         f"Skipping chaos injection for {operation.type.value} on {operation.target_node}: "
-                        "no eligible shard-safe target is currently available"
+                        f"no eligible {safety_block_reason} target is currently available"
                     )
                     return chaos_results
                 error_message = (

--- a/tests/test_chaos_coordinator.py
+++ b/tests/test_chaos_coordinator.py
@@ -108,7 +108,7 @@ def test_select_chaos_target_random(mock_live_process):
 
 def test_select_chaos_target_primary_only(mock_live_process):
     """Test selecting chaos target with primary_only strategy"""
-    coordinator = ChaosCoordinator()
+    coordinator = ChaosCoordinator(seed=1)
     cluster_id = "test-cluster"
 
     nodes = [
@@ -133,6 +133,50 @@ def test_select_chaos_target_primary_only(mock_live_process):
             process=mock_live_process,
             data_dir="/tmp/test",
             log_file="/tmp/test.log"
+        ),
+        NodeInfo(
+            node_id="node-2",
+            role="primary",
+            shard_id=1,
+            port=7002,
+            bus_port=17002,
+            pid=12347,
+            process=mock_live_process,
+            data_dir="/tmp/test",
+            log_file="/tmp/test.log"
+        ),
+        NodeInfo(
+            node_id="node-3",
+            role="replica",
+            shard_id=1,
+            port=7003,
+            bus_port=17003,
+            pid=12348,
+            process=mock_live_process,
+            data_dir="/tmp/test",
+            log_file="/tmp/test.log"
+        ),
+        NodeInfo(
+            node_id="node-4",
+            role="primary",
+            shard_id=2,
+            port=7004,
+            bus_port=17004,
+            pid=12349,
+            process=mock_live_process,
+            data_dir="/tmp/test",
+            log_file="/tmp/test.log"
+        ),
+        NodeInfo(
+            node_id="node-5",
+            role="replica",
+            shard_id=2,
+            port=7005,
+            bus_port=17005,
+            pid=12350,
+            process=mock_live_process,
+            data_dir="/tmp/test",
+            log_file="/tmp/test.log"
         )
     ]
     
@@ -142,7 +186,7 @@ def test_select_chaos_target_primary_only(mock_live_process):
     target = coordinator.chaos_engine.target_selector.select_target(cluster_id, target_selection)
     
     assert target is not None
-    assert target.node_id == "node-0"
+    assert target.node_id in {"node-0", "node-2", "node-4"}
     assert target.role == "primary"
 
 

--- a/tests/test_chaos_randomization.py
+++ b/tests/test_chaos_randomization.py
@@ -489,8 +489,11 @@ def test_chaos_without_randomization_is_consistent(mock_sleep, mock_cluster_conn
             cluster_id="test_cluster"
         )
     
-    # Verify chaos was injected (limited by shard-safety: 3 shards × 1 primary each)
-    assert len(chaos_injections) == 3, f"Should have 3 chaos injections (one per shard primary), got {len(chaos_injections)}"
+    # Verify chaos was injected only once: in a 3-shard cluster, a second
+    # primary kill would drop the cluster below failover quorum.
+    assert len(chaos_injections) == 1, (
+        f"Should have 1 chaos injection before quorum safety blocks more, got {len(chaos_injections)}"
+    )
     
     # Verify only SIGKILL was used (no randomization)
     chaos_types = [inj['chaos_type'] for inj in chaos_injections]

--- a/tests/test_shard_safety.py
+++ b/tests/test_shard_safety.py
@@ -1,8 +1,8 @@
 """
-Unit tests for ChaosTargetSelector shard-safety logic.
+Unit tests for ChaosTargetSelector safety logic.
 
-Covers: shard protection, thread-safety (TOCTOU race), cluster scoping,
-topology reconciliation on restart, and unrecord_kill on failed kills.
+Covers: shard protection, primary quorum protection, thread-safety (TOCTOU race),
+cluster scoping, topology reconciliation on restart, and unrecord_kill on failed kills.
 """
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -96,6 +96,103 @@ def test_offline_members_do_not_count_as_shard_survivors():
     selector.update_cluster_topology(CLUSTER, [_node("n0", 0, "primary", 7000)])
 
     result = selector.select_target(CLUSTER, TargetSelection(strategy="random"))
+    assert result is None
+
+
+def test_primary_quorum_blocks_second_primary_kill_across_shards():
+    """After one primary is down in a 3-shard cluster, no second primary kill is safe."""
+    selector = ChaosTargetSelector()
+    nodes = [
+        _node("n0", 0, "primary", 7000),
+        _node("n1", 0, "replica", 7001),
+        _node("n2", 1, "primary", 7002),
+        _node("n3", 1, "replica", 7003),
+        _node("n4", 2, "primary", 7004),
+        _node("n5", 2, "replica", 7005),
+    ]
+    selector.update_cluster_topology(CLUSTER, nodes)
+
+    selector._killed_node_ids[CLUSTER] = {"n0"}
+    selector.update_cluster_topology(
+        CLUSTER,
+        [
+            _node("n1", 0, "replica", 7001),
+            _node("n2", 1, "primary", 7002),
+            _node("n3", 1, "replica", 7003),
+            _node("n4", 2, "primary", 7004),
+            _node("n5", 2, "replica", 7005),
+        ],
+    )
+
+    result = selector.select_target(CLUSTER, TargetSelection(strategy="primary_only"))
+    assert result is None
+
+
+def test_random_strategy_avoids_primary_quorum_loss_by_picking_replica():
+    """Random selection should keep working by choosing safe replicas instead of primaries."""
+    selector = ChaosTargetSelector()
+    nodes = [
+        _node("n0", 0, "primary", 7000),
+        _node("n1", 0, "replica", 7001),
+        _node("n2", 1, "primary", 7002),
+        _node("n3", 1, "replica", 7003),
+        _node("n4", 2, "primary", 7004),
+        _node("n5", 2, "replica", 7005),
+    ]
+    selector.update_cluster_topology(CLUSTER, nodes)
+
+    selector._killed_node_ids[CLUSTER] = {"n0"}
+    selector.update_cluster_topology(
+        CLUSTER,
+        [
+            _node("n1", 0, "replica", 7001),
+            _node("n2", 1, "primary", 7002),
+            _node("n3", 1, "replica", 7003),
+            _node("n4", 2, "primary", 7004),
+            _node("n5", 2, "replica", 7005),
+        ],
+    )
+
+    for _ in range(20):
+        selected = selector.select_target(CLUSTER, TargetSelection(strategy="random"))
+        assert selected is not None
+        assert selected.node_id in {"n3", "n5"}
+        selector.unrecord_kill(CLUSTER, selected.node_id)
+
+
+def test_primary_quorum_uses_total_shard_count_not_live_primary_count():
+    """The quorum threshold must stay tied to the original shard count."""
+    selector = ChaosTargetSelector()
+    nodes = [
+        _node("n0", 0, "primary", 7000),
+        _node("n1", 0, "replica", 7001),
+        _node("n2", 1, "primary", 7002),
+        _node("n3", 1, "replica", 7003),
+        _node("n4", 2, "primary", 7004),
+        _node("n5", 2, "replica", 7005),
+        _node("n6", 3, "primary", 7006),
+        _node("n7", 3, "replica", 7007),
+        _node("n8", 4, "primary", 7008),
+        _node("n9", 4, "replica", 7009),
+    ]
+    selector.update_cluster_topology(CLUSTER, nodes)
+
+    selector._killed_node_ids[CLUSTER] = {"n0", "n2"}
+    selector.update_cluster_topology(
+        CLUSTER,
+        [
+            _node("n1", 0, "replica", 7001),
+            _node("n3", 1, "replica", 7003),
+            _node("n4", 2, "primary", 7004),
+            _node("n5", 2, "replica", 7005),
+            _node("n6", 3, "primary", 7006),
+            _node("n7", 3, "replica", 7007),
+            _node("n8", 4, "primary", 7008),
+            _node("n9", 4, "replica", 7009),
+        ],
+    )
+
+    result = selector.select_target(CLUSTER, TargetSelection(strategy="primary_only"))
     assert result is None
 
 
@@ -408,6 +505,62 @@ def test_no_safe_target_is_skipped_without_failed_chaos_result():
     op = Operation(
         type=OperationType.FAILOVER,
         target_node="shard-0-primary",
+        parameters={},
+        timing=OperationTiming(),
+    )
+
+    results = coordinator.coordinate_chaos_with_operation(
+        operation=op,
+        chaos_config=config,
+        cluster_connection=mock_conn,
+        cluster_id="c1",
+    )
+
+    assert results == []
+    assert coordinator.get_chaos_history() == []
+
+
+def test_no_quorum_safe_primary_target_is_skipped_without_failed_chaos_result():
+    """Quorum-safety exhaustion should also skip chaos without recording a failure."""
+    from src.fuzzer_engine.chaos_coordinator import ChaosCoordinator
+    from src.models import (
+        ChaosConfig, ChaosCoordination, ChaosType, ChaosTiming,
+        ProcessChaosType, TargetSelection, Operation, OperationType,
+        OperationTiming,
+    )
+
+    coordinator = ChaosCoordinator(seed=1)
+    nodes = [
+        _node("n0", 0, "primary", 7000),
+        _node("n1", 0, "replica", 7001),
+        _node("n2", 1, "primary", 7002),
+        _node("n3", 1, "replica", 7003),
+        _node("n4", 2, "primary", 7004),
+        _node("n5", 2, "replica", 7005),
+    ]
+    coordinator.register_cluster_nodes("c1", nodes)
+    coordinator.chaos_engine.target_selector._killed_node_ids["c1"] = {"n0"}
+
+    mock_conn = Mock()
+    mock_conn.get_live_nodes.return_value = [
+        {"node_id": "n1", "host": "127.0.0.1", "port": 7001, "role": "replica", "shard_id": 0},
+        {"node_id": "n2", "host": "127.0.0.1", "port": 7002, "role": "primary", "shard_id": 1},
+        {"node_id": "n3", "host": "127.0.0.1", "port": 7003, "role": "replica", "shard_id": 1},
+        {"node_id": "n4", "host": "127.0.0.1", "port": 7004, "role": "primary", "shard_id": 2},
+        {"node_id": "n5", "host": "127.0.0.1", "port": 7005, "role": "replica", "shard_id": 2},
+    ]
+    mock_conn.initial_nodes = nodes
+
+    config = ChaosConfig(
+        chaos_type=ChaosType.PROCESS_KILL,
+        target_selection=TargetSelection(strategy="primary_only"),
+        timing=ChaosTiming(),
+        coordination=ChaosCoordination(chaos_during_operation=True),
+        process_chaos_type=ProcessChaosType.SIGKILL,
+    )
+    op = Operation(
+        type=OperationType.FAILOVER,
+        target_node="shard-1-primary",
         parameters={},
         timing=OperationTiming(),
     )


### PR DESCRIPTION
## Summary
- add quorum-aware target filtering for primary chaos selections
- skip chaos safely when only quorum-breaking primary kills remain
- add regression coverage for cross-shard primary kill cases

## Root cause
The selector only enforced shard safety. In a multi-shard cluster it could still kill primaries from different shards, leaving too few live primaries for failover quorum even though each shard still had a replica alive.

## Testing
- python3 -m pytest tests/test_shard_safety.py tests/test_chaos_coordinator.py tests/test_chaos_randomization.py
- python3 -m pytest  *(environment-dependent cluster startup tests still fail locally because spawned Valkey nodes die before startup: tests/test_load_data.py, tests/test_node_restart.py, tests/test_orchestrator.py)*

Addresses #93.