### PR TITLE
Record valkey commit SHA in fuzzer artifacts manifest

### DIFF
--- a/.github/workflows/fuzzer-run.yml
+++ b/.github/workflows/fuzzer-run.yml
@@ -88,7 +88,7 @@ jobs:
                 result = results[0]
 
         manifest = {
-            "schema_version": 1,
+            "schema_version": 2,
             "results_path": "results.json" if results_path.exists() else None,
             "scenario_path": "scenario.yaml" if scenario_path.exists() else None,
             "log_files": sorted(
@@ -99,6 +99,7 @@ jobs:
             "scenario_id": result.get("scenario_id") if isinstance(result, dict) else None,
             "seed": result.get("seed") if isinstance(result, dict) else None,
             "success": result.get("success") if isinstance(result, dict) else None,
+            "valkey_sha": result.get("valkey_sha") if isinstance(result, dict) else None,
         }
         (artifact_dir / "manifest.json").write_text(
             json.dumps(manifest, indent=2),

--- a/src/cli.py
+++ b/src/cli.py
@@ -401,6 +401,7 @@ class FuzzerCLI:
             "chaos_events": len(result.chaos_events),
             "seed": result.seed,
             "error_message": result.error_message,
+            "valkey_sha": result.valkey_sha,
         }
 
         # Add final validation results if available

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -31,7 +31,10 @@ def detect_valkey_sha(binary: str) -> Optional[str]:
     try:
         out = subprocess.run(
             [binary, "--version"],
-            capture_output=True, text=True, timeout=5, check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
         ).stdout
     except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("Could not run %s --version: %s", binary, exc)

--- a/src/cluster_orchestrator/orchestrator.py
+++ b/src/cluster_orchestrator/orchestrator.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -14,6 +15,34 @@ from ..models import ClusterConfig, ClusterConnection, NodeInfo, NodePlan
 from ..utils.valkey_utils import valkey_client
 
 logger = logging.getLogger()
+
+# Matches the `sha=<hex>:<dirty>` field from `valkey-server --version`.
+# Example output: "Valkey server v=8.1.0 sha=abc1234:0 malloc=jemalloc-5.3.0 ..."
+_VERSION_SHA_RE = re.compile(r"sha=([0-9a-f]{7,40}):", re.IGNORECASE)
+
+
+def detect_valkey_sha(binary: str) -> Optional[str]:
+    """Return the git SHA the binary was built from, or None if unavailable.
+
+    Runs ``<binary> --version`` and parses the ``sha=<hex>:<dirty>`` field.
+    Release builds without git context emit ``sha=00000000:0`` — those return
+    None so callers don't try to clone an all-zero commit.
+    """
+    try:
+        out = subprocess.run(
+            [binary, "--version"],
+            capture_output=True, text=True, timeout=5, check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Could not run %s --version: %s", binary, exc)
+        return None
+    m = _VERSION_SHA_RE.search(out)
+    if not m:
+        return None
+    sha = m.group(1).lower()
+    if set(sha) == {"0"}:
+        return None
+    return sha
 
 
 class PortManager:

--- a/src/fuzzer_engine/cluster_coordinator.py
+++ b/src/fuzzer_engine/cluster_coordinator.py
@@ -65,7 +65,10 @@ class ClusterCoordinator:
 
             # Create cluster instance
             cluster_instance = ClusterInstance(
-                cluster_id=cluster_connection.cluster_id, config=config, nodes=nodes, is_ready=True,
+                cluster_id=cluster_connection.cluster_id,
+                config=config,
+                nodes=nodes,
+                is_ready=True,
                 valkey_sha=valkey_sha,
             )
 

--- a/src/fuzzer_engine/cluster_coordinator.py
+++ b/src/fuzzer_engine/cluster_coordinator.py
@@ -5,7 +5,12 @@ Cluster Coordinator - Manages cluster lifecycle and interfaces with Cluster Orch
 import logging
 from typing import Optional
 
-from ..cluster_orchestrator.orchestrator import ClusterManager, ConfigurationManager, PortManager
+from ..cluster_orchestrator.orchestrator import (
+    ClusterManager,
+    ConfigurationManager,
+    PortManager,
+    detect_valkey_sha,
+)
 from ..models import ClusterConfig, ClusterInstance, ClusterStatus, NodeInfo
 
 logger = logging.getLogger()
@@ -40,6 +45,12 @@ class ClusterCoordinator:
             config.valkey_binary = valkey_binary
             logger.debug(f"Using Valkey binary: {valkey_binary}")
 
+            valkey_sha = detect_valkey_sha(valkey_binary)
+            if valkey_sha:
+                logger.info(f"Valkey binary built from commit: {valkey_sha}")
+            else:
+                logger.debug("Could not determine valkey-server build SHA")
+
             # Plan topology
             node_plans = config_manager.plan_topology()
 
@@ -54,7 +65,8 @@ class ClusterCoordinator:
 
             # Create cluster instance
             cluster_instance = ClusterInstance(
-                cluster_id=cluster_connection.cluster_id, config=config, nodes=nodes, is_ready=True
+                cluster_id=cluster_connection.cluster_id, config=config, nodes=nodes, is_ready=True,
+                valkey_sha=valkey_sha,
             )
 
             # Store cluster instance and config manager for later cleanup

--- a/src/fuzzer_engine/fuzzer_engine.py
+++ b/src/fuzzer_engine/fuzzer_engine.py
@@ -282,6 +282,7 @@ class FuzzerEngine(IFuzzerEngine):
                 seed=scenario.seed,
                 validation_results=validation_results,
                 final_validation=final_validation,
+                valkey_sha=cluster_instance.valkey_sha if cluster_instance else None,
             )
 
             # Log test completion
@@ -307,6 +308,7 @@ class FuzzerEngine(IFuzzerEngine):
                 chaos_events=chaos_events,
                 error_message=str(e),
                 seed=scenario.seed,
+                valkey_sha=cluster_instance.valkey_sha if cluster_instance else None,
             )
 
             # Log test completion

--- a/src/models.py
+++ b/src/models.py
@@ -175,6 +175,7 @@ class ClusterInstance:
     config: ClusterConfig
     nodes: list[NodeInfo]
     is_ready: bool = False
+    valkey_sha: Optional[str] = None  # Git SHA the cluster's valkey-server was built from
 
 
 @dataclass
@@ -239,6 +240,7 @@ class ExecutionResult:
     seed: Optional[int] = None
     validation_results: Optional[list["StateValidationResult"]] = None  # Per-operation validation results
     final_validation: Optional["StateValidationResult"] = None  # Final validation result
+    valkey_sha: Optional[str] = None  # Git SHA of the valkey binary under test, if known
 
 
 @dataclass

--- a/tests/test_detect_valkey_sha.py
+++ b/tests/test_detect_valkey_sha.py
@@ -1,0 +1,63 @@
+"""Tests for detect_valkey_sha — parses git SHA from `valkey-server --version`."""
+
+import subprocess
+from unittest.mock import patch
+
+from src.cluster_orchestrator.orchestrator import detect_valkey_sha
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=["valkey-server", "--version"],
+                                       returncode=0, stdout=stdout, stderr="")
+
+
+def test_parses_full_sha_from_version_output():
+    out = "Valkey server v=8.1.0 sha=abc1234567890def:0 malloc=jemalloc-5.3.0 bits=64 build=abcdef1234567890"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") == "abc1234567890def"
+
+
+def test_parses_short_sha():
+    out = "Valkey server v=8.1.0 sha=abc1234:0 malloc=jemalloc-5.3.0 bits=64 build=abc"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") == "abc1234"
+
+
+def test_handles_dirty_marker():
+    """`sha=<hex>:1` indicates a dirty tree — we still record the underlying commit."""
+    out = "Valkey server v=8.1.0 sha=deadbeefcafe:1 malloc=jemalloc-5.3.0 bits=64 build=x"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") == "deadbeefcafe"
+
+
+def test_returns_none_for_release_build_with_no_git_context():
+    """Release tarballs emit `sha=00000000:0` — record None so callers don't
+    try to clone an all-zero commit."""
+    out = "Valkey server v=8.1.0 sha=00000000:0 malloc=libc bits=64 build=x"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") is None
+
+
+def test_returns_none_when_version_string_missing_sha_field():
+    out = "Valkey server v=8.1.0 malloc=libc bits=64 build=x"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") is None
+
+
+def test_returns_none_when_binary_invocation_fails():
+    """Permission/path errors should not bubble — return None and let the
+    fuzzer continue without an embedded SHA."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("nope")):
+        assert detect_valkey_sha("/missing/binary") is None
+
+
+def test_returns_none_on_subprocess_timeout():
+    with patch("subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") is None
+
+
+def test_case_insensitive_sha_lowercased():
+    out = "Valkey server v=8.1.0 sha=ABCDEF1234:0 malloc=libc bits=64"
+    with patch("subprocess.run", return_value=_ok(out)):
+        assert detect_valkey_sha("/usr/bin/valkey-server") == "abcdef1234"

--- a/tests/test_detect_valkey_sha.py
+++ b/tests/test_detect_valkey_sha.py
@@ -7,8 +7,7 @@ from src.cluster_orchestrator.orchestrator import detect_valkey_sha
 
 
 def _ok(stdout: str) -> subprocess.CompletedProcess:
-    return subprocess.CompletedProcess(args=["valkey-server", "--version"],
-                                       returncode=0, stdout=stdout, stderr="")
+    return subprocess.CompletedProcess(args=["valkey-server", "--version"], returncode=0, stdout=stdout, stderr="")
 
 
 def test_parses_full_sha_from_version_output():
@@ -52,8 +51,7 @@ def test_returns_none_when_binary_invocation_fails():
 
 
 def test_returns_none_on_subprocess_timeout():
-    with patch("subprocess.run",
-               side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5)):
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5)):
         assert detect_valkey_sha("/usr/bin/valkey-server") is None
 
 


### PR DESCRIPTION
The fuzzer artifact manifest currently records `scenario_id`, `seed`, and `success`, but not the Valkey commit SHA the run was actually testing. The analyzer in valkey-ci-agent (https://github.com/valkey-io/valkey-ci-agent/pull/2) wants to shallow-clone valkey at the exact tree that crashed so Claude Code can grep assertion text and crash handlers without hallucinating line numbers. Without the SHA in the manifest, the only safe fallback is "don't cite source", which throws away most of the value.

This adds the SHA to `results.json` and to `manifest.json` and bumps `schema_version` to 2.

## How the SHA is resolved

The orchestrator already gets `valkey-server` one of three ways: a user-configured path, `valkey-server` on `PATH`, or `git clone` + `make`. Only the third actually has a source tree we could `git rev-parse`. The universal answer is the binary itself — `valkey-server --version` includes `sha=<hex>:<dirty>`, embedded at build time via `serverGitSHA1()`. That works for all three paths.

Release builds without git context emit `sha=00000000:0`. We record `None` for those rather than writing an all-zero SHA that downstream tools would try to clone.

The detection happens once per cluster, in the orchestrator after the binary is resolved. The result rides through `ClusterInstance` → `ExecutionResult` → `results.json`, and the workflow's manifest step picks it up alongside `scenario_id` / `seed` / `success`.

## Backward compatibility

- `results.json` gains a top-level `valkey_sha` (string or null).
- `manifest.json` gains the same field; `schema_version` goes from 1 to 2 so consumers can pin against the schema rather than probing for the field.
- No CLI flag, no config change, no new dependency.

The DSL-parse-error and DSL-execution-error paths in `fuzzer_engine.py` deliberately leave `valkey_sha=None` because they fire before any cluster is created and there's no binary to ask.

## Tests

New `tests/test_detect_valkey_sha.py` covers full SHA, short SHA, dirty marker, the all-zero release case, missing `sha=` field, missing binary, subprocess timeout, and case-insensitive parsing. The existing `test_cluster_coordinator::test_create_cluster_success` exercises the real `ClusterInstance(valkey_sha=...)` construction path.

`pytest tests/ -q` (excluding `test_fuzzer_e2e.py`, `test_fuzzer_engine_integration.py`, and `test_node_restart.py` which need a live cluster) — 225 passing.
